### PR TITLE
Create Validator command to help catch any issues in the setup

### DIFF
--- a/app/Commands/BuildStaticSiteCommand.php
+++ b/app/Commands/BuildStaticSiteCommand.php
@@ -112,46 +112,6 @@ class BuildStaticSiteCommand extends Command
             base_path('_site' . DIRECTORY_SEPARATOR . 'index.html')
         ));
 
-        if (($this->option('no-ansi') && !file_exists('_site/media/app.css'))) {
-            $this->warn('Could not find the app stylesheet in the build directory. You may need to run `npm run dev`.');
-        }
-
-        if (Features::hasDocumentationPages()) {
-            if (!file_exists('_docs/index.md') && !file_exists('_site/docs/index.html')) {
-                $this->newLine();
-                $docIndexMissingMessage = 'Could not find an index.md file in the _docs directory. ';
-                // @todo add case-sensitivity support to allow both readme.md and README.md on UNIX system
-                if (file_exists('_docs/readme.md')) {
-                    $docIndexMissingMessage .= 'However, a readme.md file was found.';
-                    $this->warn($docIndexMissingMessage);
-                        $this->line($this->option('no-interaction')
-                        ? 'You can re-run this command without the --no-interaction flag to copy it to index.md. '
-                        : 'Would you like to copy it to index.md?');
-                        if ($this->choice('Create _docs/index.md from _docs/readme.md?',
-                                ['Yes', 'No'],
-                                0) == 'Yes') {
-                            $this->line('Okay, creating the file!');
-                            try {
-                                copy('_docs/readme.md', '_docs/index.md');
-                                $this->debug((new StaticPageBuilder((new DocumentationPageParser('index'))->get(),
-                                    true))->getDebugOutput());
-                                $this->line('Created _docs/index.md and _site/docs/index.html!');
-                            } catch (Exception $exception) {
-                                $this->error('Something went wrong when trying to save the file!');
-                                $this->warn($exception->getMessage());
-                                return $exception->getCode() ?? 1;
-                            }
-                        } else {
-                            $this->line('Alright. You can always rerun this command or create it manually!');
-                        }
-
-                } else {
-                    $docIndexMissingMessage .= 'You may want to create one. ';
-                    $this->warn($docIndexMissingMessage);
-                }
-            }
-        }
-
         return 0;
     }
 }

--- a/app/Commands/MakeValidatorCommand.php
+++ b/app/Commands/MakeValidatorCommand.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Commands;
+
+use LaravelZero\Framework\Commands\Command;
+use Illuminate\Support\Str; 
+
+class MakeValidatorCommand extends Command
+{
+    /**
+     * The signature of the command.
+     *
+     * @var string
+     */
+    protected $signature = 'make:validator {--name= : The name of the test} {--force : Overwrite existing files}';
+
+    /**
+     * The description of the command.
+     *
+     * @var string
+     */
+    protected $description = 'Create a validator test';
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        $this->info('Creating new Validation Test!');
+        $name = $this->option('name') ?? $this->ask('What does the validator do?');
+        $testName = strtolower($name);
+        $slug = str_replace(' ', '', Str::title($name)) . 'Test.php';
+
+        $content =
+        "<?php
+
+test('{$testName}', function () {
+    // 
+})->group('validators');
+";
+
+        $path = realpath('tests/Validators') . DIRECTORY_SEPARATOR . $slug;
+
+        if (file_exists($path) && !$this->option('force')) {
+            $this->error('Validator already exists!');
+            return 409;
+        } 
+
+
+        file_put_contents($path, $content);
+
+        $this->line("Created file $path");
+
+        return 0;
+    }
+}

--- a/app/Commands/Validate.php
+++ b/app/Commands/Validate.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Commands;
+
+use Illuminate\Console\Scheduling\Schedule;
+use LaravelZero\Framework\Commands\Command;
+
+class Validate extends Command
+{
+    /**
+     * The signature of the command.
+     *
+     * @var string
+     */
+    protected $signature = 'validate';
+
+    /**
+     * The description of the command.
+     *
+     * @var string
+     */
+    protected $description = 'Run a series of tests to validate your setup and help you optimize your site.';
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        $this->info('Running validation tests!');
+
+        $this->line(shell_exec(realpath('./vendor/bin/pest') . ' --group=validators'));
+
+        $this->info('All done!');
+    }
+}

--- a/config/commands.php
+++ b/config/commands.php
@@ -62,6 +62,7 @@ return [
         Illuminate\Console\Scheduling\ScheduleListCommand::class,
         Illuminate\Console\Scheduling\ScheduleFinishCommand::class,
         LaravelZero\Framework\Commands\StubPublishCommand::class,
+        App\Commands\MakeValidatorCommand::class,
         App\Commands\Debug::class,
     ],
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -15,10 +15,18 @@
         <testsuite name="Unit">
             <directory suffix="Test.php">./tests/Unit</directory>
         </testsuite>
+        <testsuite name="Validators">
+            <directory suffix="Test.php">./tests/Validators</directory>
+        </testsuite>
     </testsuites>
     <coverage processUncoveredFiles="true">
         <include>
             <directory suffix=".php">./app</directory>
         </include>
     </coverage>
+    <groups>
+        <exclude>
+            <group>validators</group>
+        </exclude>
+    </groups> 
 </phpunit>

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -43,3 +43,5 @@ function something()
 {
     // ..
 }
+
+uses()->group('validators')->in('validators');

--- a/tests/Validators/CheckForPageConflictsTest.php
+++ b/tests/Validators/CheckForPageConflictsTest.php
@@ -1,0 +1,17 @@
+<?php
+
+test('there are no conflicts between blade and markdown pages', function () {
+    $markdownPages = [];
+    $bladePages = [];
+
+    foreach (array_diff(scandir('_pages'), array('..', '.')) as $page) {
+        $markdownPages[] = basename($page, '.md');
+    }
+
+    foreach (array_diff(scandir('resources/views/pages'), array('..', '.')) as $page) {
+        $bladePages[] = basename($page, '.blade.php');
+    }
+
+    $conflicts = array_intersect($markdownPages, $bladePages);
+    expect($conflicts)->toBeEmpty();
+})->group('validators');

--- a/tests/Validators/CheckForPageConflictsTest.php
+++ b/tests/Validators/CheckForPageConflictsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-test('there are no conflicts between blade and markdown pages', function () {
+test('check for conflicts between blade and markdown pages', function () {
     $markdownPages = [];
     $bladePages = [];
 
@@ -13,5 +13,11 @@ test('there are no conflicts between blade and markdown pages', function () {
     }
 
     $conflicts = array_intersect($markdownPages, $bladePages);
-    expect($conflicts)->toBeEmpty();
+    
+    if (count($conflicts)) {
+        $this->addWarning('Found conflicts: ' . implode(', ', $conflicts)); 
+    } else {
+        expect($conflicts)->toBeEmpty();
+    }
+   
 })->group('validators');

--- a/tests/Validators/CheckThatAnIndexFileExistsTest.php
+++ b/tests/Validators/CheckThatAnIndexFileExistsTest.php
@@ -1,8 +1,12 @@
 <?php
 
 test('check that an index file exists', function () {
-    $this->assertTrue(
-        file_exists(realpath('_pages/index.md'))
-        || file_exists(realpath('resources/views/pages/index.blade.php'))
-    );
+     $assertion = file_exists(realpath('_pages/index.md'))
+               || file_exists(realpath('resources/views/pages/index.blade.php'));
+
+    if (!$assertion) {
+        $this->addWarning('Could not find an index.md or index.blade.php file!'); 
+    } else {
+        $this->assertTrue($assertion);
+    }
 })->group('validators');

--- a/tests/Validators/CheckThatAnIndexFileExistsTest.php
+++ b/tests/Validators/CheckThatAnIndexFileExistsTest.php
@@ -1,0 +1,8 @@
+<?php
+
+test('check that an index file exists', function () {
+    $this->assertTrue(
+        file_exists(realpath('_pages/index.md'))
+        || file_exists(realpath('resources/views/pages/index.blade.php'))
+    );
+})->group('validators');

--- a/tests/Validators/CheckThatDocumentationPagesHaveAnIndexPageTest.php
+++ b/tests/Validators/CheckThatDocumentationPagesHaveAnIndexPageTest.php
@@ -13,7 +13,7 @@ beforeEach(function () {
 
 test('check that documentation pages have an index page', function () {
     if (!Features::hasDocumentationPages()) {
-        $this->markTestSkipped();
+        $this->markTestSkipped('Documentation page feature is disabled in config');
     }
 
     $indexFileExists = file_exists('_docs/index.md');
@@ -26,5 +26,7 @@ test('check that documentation pages have an index page', function () {
 
     if (!$indexFileExists) {
         $this->addWarning($message);  
+    } else {
+        $this->assertTrue($indexFileExists);
     }
 })->group('validators');

--- a/tests/Validators/CheckThatDocumentationPagesHaveAnIndexPageTest.php
+++ b/tests/Validators/CheckThatDocumentationPagesHaveAnIndexPageTest.php
@@ -1,0 +1,30 @@
+<?php
+
+use App\Hyde\Features;
+use Illuminate\Contracts\Console\Kernel;
+
+beforeEach(function () {
+    $app = require __DIR__.'/../../bootstrap/app.php';
+
+    $app->make(Kernel::class)->bootstrap();
+
+    return $app;
+});
+
+test('check that documentation pages have an index page', function () {
+    if (!Features::hasDocumentationPages()) {
+        $this->markTestSkipped();
+    }
+
+    $indexFileExists = file_exists('_docs/index.md');
+    $readmeFileExists = (file_exists('_docs/index.md') || (file_exists('_docs/README.md')));
+
+    $message = "Could not find an index.md file in the _docs directory!";
+    if ($readmeFileExists) {
+        $message .= " However, a _docs/readme.md file was found. A suggestion would be to copy the _docs/readme.md to _docs/index.md.";
+    }
+
+    if (!$indexFileExists) {
+        $this->addWarning($message);  
+    }
+})->group('validators');

--- a/tests/Validators/CheckThatFrontendAssetsExistTest.php
+++ b/tests/Validators/CheckThatFrontendAssetsExistTest.php
@@ -1,6 +1,17 @@
 <?php
 
-test('check that frontend assets exist', function () {
-    $this->assertTrue(file_exists('_site/media/app.css'), "\033[33mCould not find the app stylesheet in the build directory. You may need to run `npm run dev`.\033[0m");
-    $this->assertTrue(file_exists('_site/media/tailwind.css'), "\033[33mCould not find the tailwind stylesheet in the build directory. You may need to run `npm run dev`.\033[0m");
+test('check that app.css exist', function () {
+    if (!file_exists('_site/media/app.css')) {
+        $this->addWarning('Could not find the app stylesheet in the build directory. You may need to run `npm run dev`.');  
+    } else {
+        $this->assertTrue(file_exists('_site/media/app.css'));
+    }
+})->group('validators');
+
+test('check that tailwind.css exist', function () {
+    if (!file_exists('_site/media/tailwind.css')) {
+        $this->addWarning('Could not find the tailwind stylesheet in the build directory. You may need to run `npm run dev`.');  
+    } else {
+        $this->assertTrue(file_exists('_site/media/tailwind.css'));
+    }
 })->group('validators');

--- a/tests/Validators/CheckThatFrontendAssetsExistTest.php
+++ b/tests/Validators/CheckThatFrontendAssetsExistTest.php
@@ -1,0 +1,6 @@
+<?php
+
+test('check that frontend assets exist', function () {
+    $this->assertTrue(file_exists('_site/media/app.css'), "\033[33mCould not find the app stylesheet in the build directory. You may need to run `npm run dev`.\033[0m");
+    $this->assertTrue(file_exists('_site/media/tailwind.css'), "\033[33mCould not find the tailwind stylesheet in the build directory. You may need to run `npm run dev`.\033[0m");
+})->group('validators');

--- a/tests/Validators/ValidatorsCanRunTest.php
+++ b/tests/Validators/ValidatorsCanRunTest.php
@@ -1,0 +1,5 @@
+<?php
+
+test('validators can run', function () {
+  $this->assertTrue(true);
+})->group('validators');


### PR DESCRIPTION
This branch adds a new command: `php hyde validate` which runs a series of Pest tests to help catch any issues such as page conflicts or missing stylesheets.

Example output of the command:
```bash
$ php hyde validate

Running validation tests!

   PASS  Tests\Validators\CheckForPageConflictsTest
  ✓ check for conflicts between blade and markdown pages

   PASS  Tests\Validators\CheckThatAnIndexFileExistsTest
  ✓ check that an index file exists

   WARN  Tests\Validators\CheckThatDocumentationPagesHaveAnIndexPageTest
  ! check that documentation pages have an index page → Could not find an index.md file in the _docs directory!

   PASS  Tests\Validators\CheckThatFrontendAssetsExistTest
  ✓ check that app.css exist
  ✓ check that tailwind.css exist

   PASS  Tests\Validators\ValidatorsCanRunTest
  ✓ validators can run

  Tests:  1 warnings, 5 passed
  Time:   0.31s

All done!
```

This PR also fixes #10 