### PR TITLE
#14 Add publishable 404 pages

### DIFF
--- a/app/Commands/Publish404PageCommand.php
+++ b/app/Commands/Publish404PageCommand.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Commands;
+
+use LaravelZero\Framework\Commands\Command;
+
+class Publish404PageCommand extends Command
+{
+    /**
+     * The signature of the command.
+     *
+     * @var string
+     */
+    protected $signature = 'publish:404 {--type= : The view to publish. Must be Blade or Markdown }  {--force : Overwrite existing files}';
+
+    /**
+     * The description of the command.
+     *
+     * @var string
+     */
+    protected $description = 'Publish the 404 page';
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        $type = $this->option('type') ?? $this->choice(
+            'Which type of view would you like to publish?',
+            ['Blade', 'Markdown'],
+            0
+        );
+
+        $type = strtolower($type);
+
+        if (!in_array($type, ['blade', 'markdown'])) {
+            $this->error('Type `'.$type.'` is not valid. It must be either `blade` or `markdown`');
+            return 400;
+        }
+        
+        if ($type === 'blade') {
+            $source = realpath('src/resources/stubs') . DIRECTORY_SEPARATOR . '404.blade.php';
+            $path = realpath('resources/views/pages') . DIRECTORY_SEPARATOR . '404.blade.php';
+        }
+
+        if ($type === 'markdown') {
+            $source = realpath('src/resources/stubs') . DIRECTORY_SEPARATOR . '404.md';
+            $path = realpath('_pages') . DIRECTORY_SEPARATOR . '404.md';
+        }
+
+        if (file_exists($path) && !$this->option('force')) {
+            $this->error("File $path already exists!");
+            return 409;
+        }
+
+        copy($source, $path);
+
+        $this->info("Created file $path!");
+        return 0;
+    }
+
+}

--- a/src/resources/stubs/404.blade.php
+++ b/src/resources/stubs/404.blade.php
@@ -1,0 +1,505 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+    <title>404 - Page not found</title>
+
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+
+    <!-- Fonts -->
+    <link rel="dns-prefetch" href="//fonts.gstatic.com">
+    <link href="https://fonts.googleapis.com/css?family=Nunito" rel="stylesheet" type="text/css">
+
+    <!-- Styles -->
+    <style>
+        html {
+            line-height: 1.15;
+            -ms-text-size-adjust: 100%;
+            -webkit-text-size-adjust: 100%;
+        }
+
+        body {
+            margin: 0;
+        }
+
+        header,
+        nav,
+        section {
+            display: block;
+        }
+
+        footer {
+            position: absolute;
+            bottom: 1rem;
+            left: 1rem;
+        }
+
+        figcaption,
+        main {
+            display: block;
+        }
+
+        a {
+            background-color: transparent;
+            -webkit-text-decoration-skip: objects;
+        }
+
+        strong {
+            font-weight: inherit;
+        }
+
+        strong {
+            font-weight: bolder;
+        }
+
+        code {
+            font-family: monospace, monospace;
+            font-size: 1em;
+        }
+
+        dfn {
+            font-style: italic;
+        }
+
+        svg:not(:root) {
+            overflow: hidden;
+        }
+
+        button,
+        input {
+            font-family: sans-serif;
+            font-size: 100%;
+            line-height: 1.15;
+            margin: 0;
+        }
+
+        button,
+        input {
+            overflow: visible;
+        }
+
+        button {
+            text-transform: none;
+        }
+
+        button,
+        html [type="button"],
+        [type="reset"],
+        [type="submit"] {
+            -webkit-appearance: button;
+        }
+
+        button::-moz-focus-inner,
+        [type="button"]::-moz-focus-inner,
+        [type="reset"]::-moz-focus-inner,
+        [type="submit"]::-moz-focus-inner {
+            border-style: none;
+            padding: 0;
+        }
+
+        button:-moz-focusring,
+        [type="button"]:-moz-focusring,
+        [type="reset"]:-moz-focusring,
+        [type="submit"]:-moz-focusring {
+            outline: 1px dotted ButtonText;
+        }
+
+        legend {
+            -webkit-box-sizing: border-box;
+            box-sizing: border-box;
+            color: inherit;
+            display: table;
+            max-width: 100%;
+            padding: 0;
+            white-space: normal;
+        }
+
+        [type="checkbox"],
+        [type="radio"] {
+            -webkit-box-sizing: border-box;
+            box-sizing: border-box;
+            padding: 0;
+        }
+
+        [type="number"]::-webkit-inner-spin-button,
+        [type="number"]::-webkit-outer-spin-button {
+            height: auto;
+        }
+
+        [type="search"] {
+            -webkit-appearance: textfield;
+            outline-offset: -2px;
+        }
+
+        [type="search"]::-webkit-search-cancel-button,
+        [type="search"]::-webkit-search-decoration {
+            -webkit-appearance: none;
+        }
+
+        ::-webkit-file-upload-button {
+            -webkit-appearance: button;
+            font: inherit;
+        }
+
+        menu {
+            display: block;
+        }
+
+        canvas {
+            display: inline-block;
+        }
+
+        template {
+            display: none;
+        }
+
+        [hidden] {
+            display: none;
+        }
+
+        html {
+            -webkit-box-sizing: border-box;
+            box-sizing: border-box;
+            font-family: sans-serif;
+        }
+
+        *,
+        *::before,
+        *::after {
+            -webkit-box-sizing: inherit;
+            box-sizing: inherit;
+        }
+
+        p {
+            margin: 0;
+        }
+
+        button {
+            background: transparent;
+            padding: 0;
+        }
+
+        button:focus {
+            outline: 1px dotted;
+            outline: 5px auto -webkit-focus-ring-color;
+        }
+
+        *,
+        *::before,
+        *::after {
+            border-width: 0;
+            border-style: solid;
+            border-color: #dae1e7;
+        }
+
+        button,
+        [type="button"],
+        [type="reset"],
+        [type="submit"] {
+            border-radius: 0;
+        }
+
+        button,
+        input {
+            font-family: inherit;
+        }
+
+        input::-webkit-input-placeholder {
+            color: inherit;
+            opacity: .5;
+        }
+
+        input:-ms-input-placeholder {
+            color: inherit;
+            opacity: .5;
+        }
+
+        input::-ms-input-placeholder {
+            color: inherit;
+            opacity: .5;
+        }
+
+        input::placeholder {
+            color: inherit;
+            opacity: .5;
+        }
+
+        button,
+        [role=button] {
+            cursor: pointer;
+        }
+
+        .bg-transparent {
+            background-color: transparent;
+        }
+
+        .bg-white {
+            background-color: #fff;
+        }
+
+        .bg-teal-light {
+            background-color: #64d5ca;
+        }
+
+        .bg-blue-dark {
+            background-color: #2779bd;
+        }
+
+        .bg-indigo-light {
+            background-color: #7886d7;
+        }
+
+        .bg-purple-light {
+            background-color: #a779e9;
+        }
+
+        .bg-no-repeat {
+            background-repeat: no-repeat;
+        }
+
+        .bg-cover {
+            background-size: cover;
+        }
+
+        .border-grey-light {
+            border-color: #dae1e7;
+        }
+
+        .hover\:border-grey:hover {
+            border-color: #b8c2cc;
+        }
+
+        .rounded-lg {
+            border-radius: .5rem;
+        }
+
+        .border-2 {
+            border-width: 2px;
+        }
+
+        .hidden {
+            display: none;
+        }
+
+        .flex {
+            display: -webkit-box;
+            display: -ms-flexbox;
+            display: flex;
+        }
+
+        .items-center {
+            -webkit-box-align: center;
+            -ms-flex-align: center;
+            align-items: center;
+        }
+
+        .justify-center {
+            -webkit-box-pack: center;
+            -ms-flex-pack: center;
+            justify-content: center;
+        }
+
+        .font-sans {
+            font-family: Nunito, sans-serif;
+        }
+
+        .font-light {
+            font-weight: 300;
+        }
+
+        .font-bold {
+            font-weight: 700;
+        }
+
+        .font-black {
+            font-weight: 900;
+        }
+
+        .h-1 {
+            height: .25rem;
+        }
+
+        .leading-normal {
+            line-height: 1.5;
+        }
+
+        .m-8 {
+            margin: 2rem;
+        }
+
+        .my-3 {
+            margin-top: .75rem;
+            margin-bottom: .75rem;
+        }
+
+        .mb-8 {
+            margin-bottom: 2rem;
+        }
+
+        .max-w-sm {
+            max-width: 30rem;
+        }
+
+        .min-h-screen {
+            min-height: 100vh;
+        }
+
+        .py-3 {
+            padding-top: .75rem;
+            padding-bottom: .75rem;
+        }
+
+        .px-6 {
+            padding-left: 1.5rem;
+            padding-right: 1.5rem;
+        }
+
+        .pb-full {
+            padding-bottom: 100%;
+        }
+
+        .absolute {
+            position: absolute;
+        }
+
+        .relative {
+            position: relative;
+        }
+
+        .pin {
+            top: 0;
+            right: 0;
+            bottom: 0;
+            left: 0;
+        }
+
+        .text-black {
+            color: #22292f;
+        }
+
+        .text-grey-darkest {
+            color: #3d4852;
+        }
+
+        .text-grey-darker {
+            color: #606f7b;
+        }
+
+        .text-2xl {
+            font-size: 1.5rem;
+        }
+
+        .text-5xl {
+            font-size: 3rem;
+        }
+
+        .uppercase {
+            text-transform: uppercase;
+        }
+
+        .antialiased {
+            -webkit-font-smoothing: antialiased;
+            -moz-osx-font-smoothing: grayscale;
+        }
+
+        .tracking-wide {
+            letter-spacing: .05em;
+        }
+
+        .w-16 {
+            width: 4rem;
+        }
+
+        .w-full {
+            width: 100%;
+        }
+
+        @media (min-width: 768px) {
+            .md\:bg-left {
+                background-position: left;
+            }
+
+            .md\:bg-right {
+                background-position: right;
+            }
+
+            .md\:flex {
+                display: -webkit-box;
+                display: -ms-flexbox;
+                display: flex;
+            }
+
+            .md\:my-6 {
+                margin-top: 1.5rem;
+                margin-bottom: 1.5rem;
+            }
+
+            .md\:min-h-screen {
+                min-height: 100vh;
+            }
+
+            .md\:pb-0 {
+                padding-bottom: 0;
+            }
+
+            .md\:text-3xl {
+                font-size: 1.875rem;
+            }
+
+            .md\:text-15xl {
+                font-size: 9rem;
+            }
+
+            .md\:w-1\/2 {
+                width: 50%;
+            }
+        }
+
+        @media (min-width: 992px) {
+            .lg\:bg-center {
+                background-position: center;
+            }
+        }
+    </style>
+</head>
+
+<body class="antialiased font-sans">
+    <div class="md:flex min-h-screen">
+        <div class="w-full md:w-1/2 bg-white flex items-center justify-center">
+            <div class="max-w-sm m-8">
+                <div class="text-black text-5xl md:text-15xl font-black">
+                    404
+                </div>
+
+                <div class="w-16 h-1 bg-purple-light my-3 md:my-6"></div>
+
+                <p class="text-grey-darker text-2xl md:text-3xl font-light mb-8 leading-normal">
+                    Sorry, the page you are looking for could not be found.
+                </p>
+
+                <a href="index.html">
+                    <button
+                        class="bg-transparent text-grey-darkest font-bold uppercase tracking-wide py-3 px-6 border-2 border-grey-light hover:border-grey rounded-lg">
+                        Go Home
+                    </button>
+                </a>
+            </div>
+
+        </div>
+
+        <div class="relative pb-full md:flex md:pb-0 md:min-h-screen w-full md:w-1/2">
+            <div style="background-image: url('https://cdn.jsdelivr.net/gh/LaravelCollective/errors@1.0/src/publish/svg/404.svg');"
+                class="absolute pin bg-cover bg-no-repeat md:bg-left lg:bg-center">
+            </div>
+        </div>
+
+        <footer>
+            <small>
+                Error page and illustration by <a href="https://github.com/LaravelCollective/errors">LaravelCollective</a> (License MIT)
+            </small>
+        </footer>
+    </div>
+</body>
+
+</html>

--- a/src/resources/stubs/404.md
+++ b/src/resources/stubs/404.md
@@ -1,0 +1,7 @@
+---
+title: 404 - Page not found
+---
+
+# 404 - Page not found
+
+[Go Home](index.html)

--- a/tests/Feature/Commands/Publish404PageCommandTest.php
+++ b/tests/Feature/Commands/Publish404PageCommandTest.php
@@ -1,0 +1,144 @@
+<?php
+
+namespace Tests\Feature\Commands;
+
+use Tests\TestCase;
+
+class Publish404PageCommandTest extends TestCase
+{
+	/**
+     * Set up the tests by making sure no conflicting files exist.
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        $this->unlink();
+		
+        parent::setUp();
+    }
+
+	/**
+     * Clean up after tests by removing the created files.
+     * @return void
+     */
+    protected function tearDown(): void
+    {
+        $this->unlink();
+
+        parent::tearDown();
+    }
+
+	private function unlink(): void
+	{
+		if (file_exists($this->getBladePath())) {
+			unlink($this->getBladePath());
+		}
+		if (file_exists($this->getMarkdownPath())) {
+			unlink($this->getMarkdownPath());
+		}
+	}
+
+	private function getBladePath(): string
+	{
+		return realpath('resources/views/pages') . DIRECTORY_SEPARATOR . '404.blade.php';
+	}
+
+	private function getMarkdownPath(): string
+	{
+		return realpath('_pages') . DIRECTORY_SEPARATOR . '404.md';
+	}
+
+    public function test_command_exists()
+    {
+		$this->artisan('publish:404 --help')->assertExitCode(0);
+		$this->assertCommandCalled('publish:404 --help');
+    }
+
+	public function test_command_creates_blade_file()
+	{
+		$path = $this->getBladePath();
+
+		// Assert that no old file exists which would cause issues
+		$this->assertFileDoesNotExist($path);
+
+		$this->artisan('publish:404 --type="blade" --no-interaction')
+			->expectsOutput("Created file $path!")
+			->assertExitCode(0);
+
+		$this->assertFileExists($path);
+	}
+	
+	public function test_command_creates_markdown_file()
+	{
+		$path = $this->getMarkdownPath();
+
+		// Assert that no old file exists which would cause issues
+		$this->assertFileDoesNotExist($path);
+
+		$this->artisan('publish:404 --type="markdown" --no-interaction')
+			->expectsOutput("Created file $path!")
+			->assertExitCode(0);
+
+		$this->assertFileExists($path);
+	}
+
+	public function test_command_does_not_accept_invalid_type()
+	{
+		$this->artisan('publish:404 --type="invalid-type"')
+			->expectsOutput('Type `invalid-type` is not valid. It must be either `blade` or `markdown`')
+			->assertExitCode(400);
+
+		$this->artisan('publish:404')
+			->expectsQuestion('Which type of view would you like to publish?', 'invalid-type')
+			->expectsOutput('Type `invalid-type` is not valid. It must be either `blade` or `markdown`')
+			->assertExitCode(400);
+	}
+
+	public function test_command_does_not_overwrite_existing_files()
+	{
+		$path = $this->getMarkdownPath();
+
+		file_put_contents($path, "Test File");
+
+		// Assert that the created file exists
+		$this->assertFileExists($path);
+		
+		$this->artisan('publish:404 --type="markdown" --no-interaction')
+			->expectsOutput("File $path already exists!")
+			->assertExitCode(409);
+
+		// Assert the file contents were not overwritten
+		$this->assertStringContainsString('Test File',
+            file_get_contents($path));
+	}
+
+	public function test_command_does_overwrite_existing_files_when_force_flag_is_set()
+	{
+		$path = $this->getMarkdownPath();
+
+		file_put_contents($path, "Test File");
+
+		// Assert that the created file exists
+		$this->assertFileExists($path);
+		
+		$this->artisan('publish:404 --type="markdown" --force --no-interaction')
+			->expectsOutput("Created file $path!")
+			->assertExitCode(0);
+
+		// Assert the file contents were overwritten
+		$this->assertStringNotContainsString('Test File',
+            file_get_contents($path));
+	}
+
+	public function test_command_is_interactive_and_uses_the_supplied_answer()
+	{
+		$markdownPath = $this->getMarkdownPath();
+		$bladePath = $this->getBladePath();
+
+		$this->artisan('publish:404')
+			->expectsQuestion('Which type of view would you like to publish?', 'Markdown')
+			->expectsOutput("Created file $markdownPath!")
+			->doesntExpectOutput("Created file $bladePath!")
+			->assertExitCode(0);
+	}
+}

--- a/tests/Validators/CheckIfA404PageExistsTest.php
+++ b/tests/Validators/CheckIfA404PageExistsTest.php
@@ -1,0 +1,12 @@
+<?php
+
+test('check if a 404 page exists', function () {
+    $assertion = file_exists(realpath('_pages/404.md'))
+    || file_exists(realpath('resources/views/pages/404.blade.php'));
+
+    if (!$assertion) {
+    $this->addWarning('Could not find an 404.md or 404.blade.php file! You can scaffold one using `php hyde publish:404`'); 
+    } else {
+    $this->assertTrue($assertion);
+    }
+})->group('validators');


### PR DESCRIPTION
This branch adds a new command to publish 404 pages using `php hyde publish:404`. There are two types to choose from, a simple Markdown view, and a beautiful Blade view from LaravelCollective https://github.com/LaravelCollective/errors.

It also adds a validator to check if a 404 page exists, else it prints a message about the command.

It also adds a feature test suite with 7 tests for the command.