### PR TITLE
Add the Torchlight badge automatically

### DIFF
--- a/app/Hyde/Actions/MarkdownConverter.php
+++ b/app/Hyde/Actions/MarkdownConverter.php
@@ -2,6 +2,7 @@
 
 namespace App\Hyde\Actions;
 
+use App\Hyde\Hyde;
 use League\CommonMark\CommonMarkConverter;
 use League\CommonMark\Extension\GithubFlavoredMarkdownExtension;
 use Torchlight\Commonmark\V2\TorchlightExtension;
@@ -22,10 +23,17 @@ class MarkdownConverter
         $converter = new CommonMarkConverter();
 
         $converter->getEnvironment()->addExtension(new GithubFlavoredMarkdownExtension());
-        if (config('torchlight.token') !== null) {
+
+        if (Hyde::hasTorchlight()) {
             $converter->getEnvironment()->addExtension(new TorchlightExtension());
         }
 
-        return $converter->convert($markdown);
+        $html = $converter->convert($markdown);
+
+        if (Hyde::hasTorchlight() && str_contains($html, 'Syntax highlighted by torchlight.dev')) {
+            $html .= file_get_contents(realpath('src/resources/stubs') . DIRECTORY_SEPARATOR . 'torchlight-badge.html');
+        }
+
+        return $html;
     }
 }

--- a/app/Hyde/Actions/MarkdownConverter.php
+++ b/app/Hyde/Actions/MarkdownConverter.php
@@ -30,7 +30,9 @@ class MarkdownConverter
 
         $html = $converter->convert($markdown);
 
-        if (Hyde::hasTorchlight() && str_contains($html, 'Syntax highlighted by torchlight.dev')) {
+        if (Hyde::hasTorchlight()
+            && config('torchlight.attribution', true)
+            && str_contains($html, 'Syntax highlighted by torchlight.dev')) {
             $html .= file_get_contents(realpath('src/resources/stubs') . DIRECTORY_SEPARATOR . 'torchlight-badge.html');
         }
 

--- a/src/resources/stubs/torchlight-badge.html
+++ b/src/resources/stubs/torchlight-badge.html
@@ -1,0 +1,5 @@
+<p class="mt-8">
+	<i>
+		Syntax highlighting by <a href="https://torchlight.dev/" rel="noopener nofollow">Torchlight.dev</a>
+	</i>
+</p>


### PR DESCRIPTION
Fixes #8 by implementing the feature to automatically inject the Torchlight attribution badge on pages that use it, unless it is disabled in the config.