### PR TITLE
Improve the front matter parser to fix #21

### DIFF
--- a/app/Hyde/MarkdownPostParser.php
+++ b/app/Hyde/MarkdownPostParser.php
@@ -122,8 +122,29 @@ class MarkdownPostParser
     {
         $matter = [];
         foreach ($lines as $line) {
+            if (!str_contains($line, ':')) {
+                continue; // The front matter is invalid, so we skip the line.
+            }
+
+            // Separate the key from the value
             $array = (explode(': ', $line, 2));
-            $matter[$array[0]] = $array[1];
+
+            // Assign the split values into variables so it's easier to keep track of them.
+            $key = $array[0];
+            $value = $array[1];
+
+            // Filter the value to ensure a predictable state
+
+            // Remove quotes while allowing quotes within the actual text
+            if (str_starts_with($value, '"') && str_ends_with($value, '"')) {
+                $value = substr($value, 1);
+                $value = substr($value, 0, -1);
+            }
+            
+            // Trim trailing whitespace
+            $value = trim($value, ' ');
+
+            $matter[$key] = $value;
         }
         return $matter;
     }


### PR DESCRIPTION
This PR fixes the bug in #21 where the front matter parser included quote marks in the output.

It also strips trailing whitespace, note the space after "blog " in the category in the first image.

Before:
![_D__Dev_Laravel_ProjectHyde_HydeZero__site_posts_my-new-post html](https://user-images.githubusercontent.com/95144705/159173525-15671084-0c67-445f-a9a3-c3cd01526df5.png)

After:
![_D__Dev_Laravel_ProjectHyde_HydeZero__site_posts_my-new-post html (1)](https://user-images.githubusercontent.com/95144705/159173547-682e1d4d-e41d-4044-b3d9-841a76450c5a.png)

It also adds a check to lines missing the colon delimiter (`:`) to skip empty or malformed YAML.
