### PR TITLE
Add support for images

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,13 @@ The site also works great when browsing the HTML files locally.
 
 If it is the first time building the site or if you have updated the source SCSS you also need to run `npm install && npm run dev` to build the frontend assets.
 
+#### Adding images
+All media files in the `_media` directory will get copied to the `_site/media` directory upon build.
+To reference an image in your Markdown, use the following syntax
+```markdown
+![Image Alt](../media/image.png "Image Title") # Note the relative path
+```
+Nested media directories are not yet supported.
 
 #### Live preview
 Use ` npm run watch` to watch the files for changes and start up a local dev server on port 3000 using Browsersync.

--- a/app/Actions/CreatesDefaultDirectories.php
+++ b/app/Actions/CreatesDefaultDirectories.php
@@ -10,6 +10,7 @@ class CreatesDefaultDirectories
         '_drafts',
         '_pages',
         '_posts',
+        '_media',
         '_site',
         '_docs',
         '_site/posts',

--- a/app/Commands/BuildStaticSiteCommand.php
+++ b/app/Commands/BuildStaticSiteCommand.php
@@ -57,7 +57,17 @@ class BuildStaticSiteCommand extends Command
             $this->warn('Running with high verbosity');
         }
 
+        $this->line('Transferring Media Assets...');
+        $files = realpath('_media') . DIRECTORY_SEPARATOR . ("*.{png,svg,jpg,jpeg,gif,ico}");
+        $this->withProgressBar(glob($files, GLOB_BRACE), function ($filepath) {
+            if ($this->getOutput()->isVeryVerbose()) {
+                $this->line(' > Copying media file ' . basename($filepath) . ' to the output media directory');
+            }
+            copy($filepath, realpath('_site/media') . DIRECTORY_SEPARATOR . basename($filepath));
+        });
+
         if (Features::hasBlogPosts()) {
+            $this->newLine(2);
             $this->line('Creating Markdown Posts...');
             $this->withProgressBar(CollectionService::getSourceSlugsOfModels(MarkdownPost::class), function ($slug) {
                 $this->debug((new StaticPageBuilder((new MarkdownPostParser($slug))->get(), true))->getDebugOutput());


### PR DESCRIPTION
# Adding images

Resolves #24 

All media files in the _media directory will get copied to the _site/media directory upon build. To reference an image in your Markdown, use the following syntax
To reference an image in your Markdown, use the following syntax
```markdown
![Image Alt](../media/image.png "Image Title") # Note the relative path
```

Since most images are probably going to be in blog posts or documentation pages you need to prepend the `../` before the "media". However, if you are referencing the image in a Markdown page you should use `media/image.png` for the path.

Nested media directories are not yet supported.
