### PR TITLE
Add a customizable footer

### DIFF
--- a/app/Actions/ConvertsFooterMarkdown.php
+++ b/app/Actions/ConvertsFooterMarkdown.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Actions;
+
+use Illuminate\Support\Str;
+
+class ConvertsFooterMarkdown
+{
+    /**
+     * Convert the Markdown text if supplied in the config,
+	 * or fall back to default to generate HTML for the footer.
+     *
+     * @return string $html
+     */
+    public static function execute(): string
+    {
+        return Str::markdown(config('hyde.footer.markdown', 'Site built with the Free and Open Source [HydePHP](https://github.com/hydephp/hyde).
+		License [MIT](https://github.com/hydephp/hyde/blob/master/LICENSE.md).'));
+    }
+}

--- a/config/hyde.php
+++ b/config/hyde.php
@@ -9,9 +9,9 @@
 |        /___/                          
 |--------------------------------------------------------------------------
 |
-| Welcome to HydePHP! In this file you can customize your new Static Site!
+| Welcome to HydePHP! In this file, you can customize your new Static Site!
 |
-| HydePHP favors convention over configuration and as such requires virtually
+| HydePHP favours convention over configuration and as such requires virtually
 | no configuration out of the box to get started. Though, you may want to
 | change the options to personalize your site and make it your own!
 |
@@ -21,13 +21,13 @@ use App\Hyde\Features;
 
 return [
 
-	/*
+    /*
     |--------------------------------------------------------------------------
     | Site Name
     |--------------------------------------------------------------------------
     |
     | This value sets the name of your site and is, for example, used in
-    | the compiled page titles and more. Default value is "HydePHP".
+    | the compiled page titles and more. The default value is HydePHP.
     |
     */
 
@@ -40,8 +40,8 @@ return [
     |--------------------------------------------------------------------------
     |
     | Some of Hyde's features are optional. Feel free to disable the features
-    | you don't need by removing them from this array or by commenting them.
-    | This type of configuration is directly inspired by Laravel Jetstream.
+    | you don't need by removing or commenting them out from this array.
+    | This config concept is directly inspired by Laravel Jetstream.
     |
     */
 
@@ -50,6 +50,27 @@ return [
         Features::bladePages(),
         Features::markdownPages(),
         Features::documentationPages(),
+    ],
+
+
+    /*
+    |--------------------------------------------------------------------------
+    | Footer Text
+    |--------------------------------------------------------------------------
+    |
+    | Most websites have a footer with copyright details and contact information.
+    | You probably want to change the Markdown to include your information,
+    | though you are of course welcome to keep the attribution link! 
+    |
+    | You can also customize the blade view if you want a more complex footer.
+    | You can disable it completely by setting `enabled` to `false`.
+    |
+    */
+    
+    'footer' => [
+        'enabled' => true,
+        'markdown' => 'Site built with the Free and Open Source [HydePHP](https://github.com/hydephp/hyde).
+                       License [MIT](https://github.com/hydephp/hyde/blob/master/LICENSE.md).'
     ],
 
 

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -21,13 +21,13 @@
 
     @include('layouts.meta') 
 </head>
-<body id="app" class="overflow-x-hidden">
+<body id="app" class="flex flex-col min-h-screen overflow-x-hidden">
     @includeUnless($withoutNavigation ?? false, 'layouts.navigation') 
 
     <section id="content">
         @yield('content') 
     </section>
 
-    @include('layouts.footer') 
+    @includeWhen(config('hyde.footer.enabled', true), 'layouts.footer') 
 </body>
 </html>

--- a/resources/views/layouts/footer.blade.php
+++ b/resources/views/layouts/footer.blade.php
@@ -1,0 +1,5 @@
+<footer class="py-4 px-6 w-full bg-slate-100 text-center mt-auto">
+	<div class="prose text-center mx-auto">
+		{!! App\Actions\ConvertsFooterMarkdown::execute() !!}
+	</div>
+</footer>

--- a/resources/views/page.blade.php
+++ b/resources/views/page.blade.php
@@ -2,7 +2,7 @@
 @extends('layouts.app')
 @section('content')
 
-<main class="mx-auto max-w-7xl py-16 px-8 lg:mt-8">
+<main class="mx-auto max-w-7xl py-16 px-8">
 	<article @class(['mx-auto prose max-w-5xl', 'torchlight-enabled' => App\Hyde\Hyde::hasTorchlight()])>
 		{!! $markdown !!}
 	</article>

--- a/resources/views/pages/index.blade.php
+++ b/resources/views/pages/index.blade.php
@@ -7,7 +7,7 @@
 @extends('layouts.app')
 @section('content')
 
-<main class="mx-auto max-w-7xl py-16 px-8 lg:mt-8">
+<main class="mx-auto max-w-7xl py-12 px-8">
     <header class="lg:mb-12 xl:mb-16">
         <h1
         class="text-3xl text-left opacity-75 leading-10 tracking-tight font-extrabold sm:leading-none mb-8 md:mb-12 md:text-4xl md:text-center lg:text-5xl">

--- a/resources/views/post.blade.php
+++ b/resources/views/post.blade.php
@@ -2,7 +2,7 @@
 @extends('layouts.app')
 @section('content')
 
-<main class="mx-auto max-w-7xl py-16 px-8 lg:mt-8">
+<main class="mx-auto max-w-7xl py-16 px-8">
 	@include('components.post.article')
 </main>
 


### PR DESCRIPTION
This PR adds a customizable footer.

By default it uses Markdown defined in the `config/hyde.php`, but for more advanced footers the Blade view can be customized directly.

`config/hyde.php`
```php
/*
|--------------------------------------------------------------------------
| Footer Text
|--------------------------------------------------------------------------
*/

'footer' => [
  'enabled' => true,
  markdown' => 'Site built with the Free and Open Source [HydePHP](https://github.com/hydephp/hyde).
                           License [MIT](https://github.com/hydephp/hyde/blob/master/LICENSE.md).'
],
```

`resources\views\layouts\footer.blade.php`
```blade
<footer class="py-4 px-6 w-full bg-slate-100 text-center mt-auto">
	<div class="prose text-center mx-auto">
		{!! App\Actions\ConvertsFooterMarkdown::execute() !!}
	</div>
</footer>
```

