### PR TITLE
Add a path helper to unify path referencing

### DIFF
--- a/app/Actions/ConvertsFooterMarkdown.php
+++ b/app/Actions/ConvertsFooterMarkdown.php
@@ -8,13 +8,16 @@ class ConvertsFooterMarkdown
 {
     /**
      * Convert the Markdown text if supplied in the config,
-	 * or fall back to default to generate HTML for the footer.
+     * or fall back to default to generate HTML for the footer.
      *
      * @return string $html
      */
     public static function execute(): string
     {
-        return Str::markdown(config('hyde.footer.markdown', 'Site built with the Free and Open Source [HydePHP](https://github.com/hydephp/hyde).
-		License [MIT](https://github.com/hydephp/hyde/blob/master/LICENSE.md).'));
+        return Str::markdown(config(
+            'hyde.footer.markdown',
+            'Site built with the Free and Open Source [HydePHP](https://github.com/hydephp/hyde).
+		License [MIT](https://github.com/hydephp/hyde/blob/master/LICENSE.md).'
+        ));
     }
 }

--- a/app/Actions/CreatesDefaultDirectories.php
+++ b/app/Actions/CreatesDefaultDirectories.php
@@ -2,6 +2,7 @@
 
 namespace App\Actions;
 
+use App\Hyde\Hyde;
 use JetBrains\PhpStorm\Pure;
 
 class CreatesDefaultDirectories
@@ -22,7 +23,7 @@ class CreatesDefaultDirectories
     {
         foreach ($this->requiredDirectories as $directory) {
             // Does the directory exist?     // Otherwise, create it.
-            realpath("./$directory") || mkdir(realpath('.') . "/$directory");
+            is_dir(Hyde::path($directory)) || mkdir(Hyde::path($directory));
         }
     }
 

--- a/app/Actions/CreatesNewMarkdownPostFile.php
+++ b/app/Actions/CreatesNewMarkdownPostFile.php
@@ -3,6 +3,7 @@
 namespace App\Actions;
 
 use Exception;
+use App\Hyde\Hyde;
 use Illuminate\Support\Str;
 
 class CreatesNewMarkdownPostFile
@@ -47,15 +48,14 @@ class CreatesNewMarkdownPostFile
     /**
      * Save the class object to a Markdown file.
      *
-     * @todo Remove the slug key from the generated front matter as it is not parsed
-     *
      * @param bool $force Should the file be created even if a file with the same path already exists?
      * @return string|false Returns the path to the file if successful, or false if the file could not be saved.
      * @throws Exception if a file with the same slug already exists and the force flag is not set.
      */
     public function save(bool $force = false): string|false
     {
-        $path = realpath('./_posts') . DIRECTORY_SEPARATOR . "$this->slug.md";
+        
+        $path = Hyde::path("_posts/$this->slug.md");
 
         if ($force !== true && file_exists($path)) {
             throw new Exception("File at $path already exists! ", 409);
@@ -65,7 +65,8 @@ class CreatesNewMarkdownPostFile
 
         unset($arrayWithoutSlug['slug']);
 
-        $contents = (new ConvertsArrayToFrontMatter)->execute($arrayWithoutSlug) . "\n## Write something awesome.\n\n";
+        $contents = (new ConvertsArrayToFrontMatter)->execute($arrayWithoutSlug) . 
+            "\n## Write something awesome.\n\n";
 
         return file_put_contents($path, $contents) ? $path : false;
     }

--- a/app/Actions/CreatesNewMarkdownPostFile.php
+++ b/app/Actions/CreatesNewMarkdownPostFile.php
@@ -65,7 +65,7 @@ class CreatesNewMarkdownPostFile
 
         unset($arrayWithoutSlug['slug']);
 
-        $contents = (new ConvertsArrayToFrontMatter)->execute($arrayWithoutSlug) . 
+        $contents = (new ConvertsArrayToFrontMatter)->execute($arrayWithoutSlug) .
             "\n## Write something awesome.\n\n";
 
         return file_put_contents($path, $contents) ? $path : false;

--- a/app/Actions/GeneratesNavigationMenu.php
+++ b/app/Actions/GeneratesNavigationMenu.php
@@ -45,9 +45,9 @@ class GeneratesNavigationMenu
 
     /**
      * Create the link array
-     * 
+     *
      * @todo Cache the base array and only update the 'current' attribute on each request.
-     * 
+     *
      * @return array
      */
     private function getLinks(): array

--- a/app/Actions/GeneratesNavigationMenu.php
+++ b/app/Actions/GeneratesNavigationMenu.php
@@ -3,6 +3,7 @@
 namespace App\Actions;
 
 use App\Hyde\Features;
+use App\Hyde\Hyde;
 use App\Hyde\Models\MarkdownPage;
 use Illuminate\Support\Str;
 
@@ -151,7 +152,7 @@ class GeneratesNavigationMenu
     {
         $array = [];
 
-        foreach (glob(base_path('resources/views/pages/*.blade.php')) as $path) {
+        foreach (glob(Hyde::path('resources/views/pages/*.blade.php')) as $path) {
             $array[] = basename($path, '.blade.php');
         }
 

--- a/app/Commands/BuildStaticSiteCommand.php
+++ b/app/Commands/BuildStaticSiteCommand.php
@@ -7,6 +7,7 @@ use LaravelZero\Framework\Commands\Command;
 use App\Hyde\Services\CollectionService;
 use App\Hyde\DocumentationPageParser;
 use App\Hyde\Features;
+use App\Hyde\Hyde;
 use App\Hyde\MarkdownPostParser;
 use App\Hyde\MarkdownPageParser;
 use App\Hyde\StaticPageBuilder;
@@ -58,12 +59,12 @@ class BuildStaticSiteCommand extends Command
         }
 
         $this->line('Transferring Media Assets...');
-        $files = realpath('_media') . DIRECTORY_SEPARATOR . ("*.{png,svg,jpg,jpeg,gif,ico}");
-        $this->withProgressBar(glob($files, GLOB_BRACE), function ($filepath) {
+        $this->withProgressBar(glob(Hyde::path('_media/*.{png,svg,jpg,jpeg,gif,ico}'), GLOB_BRACE), function ($filepath) {
             if ($this->getOutput()->isVeryVerbose()) {
                 $this->line(' > Copying media file ' . basename($filepath) . ' to the output media directory');
             }
-            copy($filepath, realpath('_site/media') . DIRECTORY_SEPARATOR . basename($filepath));
+            
+            copy($filepath, Hyde::path('_site/media/'. basename($filepath)));
         });
 
         if (Features::hasBlogPosts()) {
@@ -119,7 +120,7 @@ class BuildStaticSiteCommand extends Command
         $this->info('Congratulations! 🎉 Your static site has been built!');
         $this->info(sprintf(
             "Your new homepage is stored here -> %s",
-            base_path('_site' . DIRECTORY_SEPARATOR . 'index.html')
+            Hyde::path('_site/index.html')
         ));
 
         return 0;

--- a/app/Commands/BuildStaticSiteCommand.php
+++ b/app/Commands/BuildStaticSiteCommand.php
@@ -59,45 +59,61 @@ class BuildStaticSiteCommand extends Command
         }
 
         $this->line('Transferring Media Assets...');
-        $this->withProgressBar(glob(Hyde::path('_media/*.{png,svg,jpg,jpeg,gif,ico}'), GLOB_BRACE), function ($filepath) {
-            if ($this->getOutput()->isVeryVerbose()) {
-                $this->line(' > Copying media file ' . basename($filepath) . ' to the output media directory');
-            }
+        $this->withProgressBar(
+            glob(Hyde::path('_media/*.{png,svg,jpg,jpeg,gif,ico}'), GLOB_BRACE),
+            function ($filepath) {
+                if ($this->getOutput()->isVeryVerbose()) {
+                    $this->line(' > Copying media file '
+                    . basename($filepath). ' to the output media directory');
+                }
             
-            copy($filepath, Hyde::path('_site/media/'. basename($filepath)));
-        });
+                copy($filepath, Hyde::path('_site/media/'. basename($filepath)));
+            }
+        );
 
         if (Features::hasBlogPosts()) {
             $this->newLine(2);
             $this->line('Creating Markdown Posts...');
-            $this->withProgressBar(CollectionService::getSourceSlugsOfModels(MarkdownPost::class), function ($slug) {
-                $this->debug((new StaticPageBuilder((new MarkdownPostParser($slug))->get(), true))->getDebugOutput());
-            });
+            $this->withProgressBar(
+                CollectionService::getSourceSlugsOfModels(MarkdownPost::class),
+                function ($slug) {
+                    $this->debug((new StaticPageBuilder((new MarkdownPostParser($slug))->get(), true))
+                    ->getDebugOutput());
+                }
+            );
         }
 
         if (Features::hasMarkdownPages()) {
             $this->newLine(2);
             $this->line('Creating Markdown Pages...');
-            $this->withProgressBar(CollectionService::getSourceSlugsOfModels(MarkdownPage::class), function ($slug) {
-                $this->debug((new StaticPageBuilder((new MarkdownPageParser($slug))->get(), true))->getDebugOutput());
-            });
+            $this->withProgressBar(
+                CollectionService::getSourceSlugsOfModels(MarkdownPage::class),
+                function ($slug) {
+                    $this->debug((new StaticPageBuilder((new MarkdownPageParser($slug))->get(), true))
+                        ->getDebugOutput());
+                }
+            );
         }
 
         if (Features::hasDocumentationPages()) {
             $this->newLine(2);
             $this->line('Creating Documentation Pages...');
-            $this->withProgressBar(CollectionService::getSourceSlugsOfModels(DocumentationPage::class), function ($slug) {
-                $this->debug((new StaticPageBuilder((new DocumentationPageParser($slug))->get(), true))->getDebugOutput());
-            });
+            $this->withProgressBar(
+                CollectionService::getSourceSlugsOfModels(DocumentationPage::class),
+                function ($slug) {
+                    $this->debug((new StaticPageBuilder((new DocumentationPageParser($slug))->get(), true))
+                    ->getDebugOutput());
+                }
+            );
         }
 
-       if (Features::hasBladePages()) {
+        if (Features::hasBladePages()) {
             $this->newLine(2);
             $this->line('Creating Blade Pages...');
             $this->withProgressBar(CollectionService::getSourceSlugsOfModels(BladePage::class), function ($slug) {
                 $this->debug((new StaticPageBuilder((new BladePage($slug)), true))->getDebugOutput());
             });
-       }
+        }
 
         $this->newLine(2);
 

--- a/app/Commands/Debug.php
+++ b/app/Commands/Debug.php
@@ -3,6 +3,7 @@
 namespace App\Commands;
 
 use App\Actions\Installer\Installer;
+use App\Hyde\Hyde;
 use LaravelZero\Framework\Commands\Command;
 
 class Debug extends Command
@@ -29,6 +30,10 @@ class Debug extends Command
     public function handle(): int
     {
         $this->info('HydePHP Debug Screen');
+
+        $this->newLine();
+        $this->line('Project directory:');
+        $this->line(' > ' . Hyde::path());
 
         $this->newLine();
 

--- a/app/Commands/MakeValidatorCommand.php
+++ b/app/Commands/MakeValidatorCommand.php
@@ -2,8 +2,9 @@
 
 namespace App\Commands;
 
+use App\Hyde\Hyde;
 use LaravelZero\Framework\Commands\Command;
-use Illuminate\Support\Str; 
+use Illuminate\Support\Str;
 
 class MakeValidatorCommand extends Command
 {
@@ -24,9 +25,9 @@ class MakeValidatorCommand extends Command
     /**
      * Execute the console command.
      *
-     * @return mixed
+     * @return int
      */
-    public function handle()
+    public function handle(): int
     {
         $this->info('Creating new Validation Test!');
         $name = $this->option('name') ?? $this->ask('What does the validator do?');
@@ -37,16 +38,16 @@ class MakeValidatorCommand extends Command
         "<?php
 
 test('{$testName}', function () {
-    // 
+    //
 })->group('validators');
 ";
 
-        $path = realpath('tests/Validators') . DIRECTORY_SEPARATOR . $slug;
+        $path = Hyde::path("tests/Validators/$slug");
 
         if (file_exists($path) && !$this->option('force')) {
             $this->error('Validator already exists!');
             return 409;
-        } 
+        }
 
 
         file_put_contents($path, $content);

--- a/app/Commands/Publish404PageCommand.php
+++ b/app/Commands/Publish404PageCommand.php
@@ -12,7 +12,9 @@ class Publish404PageCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'publish:404 {--type= : The view to publish. Must be Blade or Markdown }  {--force : Overwrite existing files}';
+    protected $signature = 'publish:404 
+                                {--type= : The view to publish. Must be Blade or Markdown }
+                                {--force : Overwrite existing files}';
 
     /**
      * The description of the command.
@@ -61,5 +63,4 @@ class Publish404PageCommand extends Command
         $this->info("Created file $path!");
         return 0;
     }
-
 }

--- a/app/Commands/Publish404PageCommand.php
+++ b/app/Commands/Publish404PageCommand.php
@@ -2,6 +2,7 @@
 
 namespace App\Commands;
 
+use App\Hyde\Hyde;
 use LaravelZero\Framework\Commands\Command;
 
 class Publish404PageCommand extends Command
@@ -41,13 +42,13 @@ class Publish404PageCommand extends Command
         }
         
         if ($type === 'blade') {
-            $source = realpath('src/resources/stubs') . DIRECTORY_SEPARATOR . '404.blade.php';
-            $path = realpath('resources/views/pages') . DIRECTORY_SEPARATOR . '404.blade.php';
+            $source = Hyde::path('src/resources/stubs/404.blade.php');
+            $path = Hyde::path('resources/views/pages/404.blade.php');
         }
 
         if ($type === 'markdown') {
-            $source = realpath('src/resources/stubs') . DIRECTORY_SEPARATOR . '404.md';
-            $path = realpath('_pages') . DIRECTORY_SEPARATOR . '404.md';
+            $source = Hyde::path('src/resources/stubs/404.md');
+            $path = Hyde::path('_pages/404.md');
         }
 
         if (file_exists($path) && !$this->option('force')) {

--- a/app/Commands/Validate.php
+++ b/app/Commands/Validate.php
@@ -2,7 +2,7 @@
 
 namespace App\Commands;
 
-use Illuminate\Console\Scheduling\Schedule;
+use App\Hyde\Hyde;
 use LaravelZero\Framework\Commands\Command;
 
 class Validate extends Command
@@ -30,7 +30,7 @@ class Validate extends Command
     {
         $this->info('Running validation tests!');
 
-        $this->line(shell_exec(realpath('./vendor/bin/pest') . ' --group=validators'));
+        $this->line(shell_exec(Hyde::path('vendor/bin/pest') . ' --group=validators'));
 
         $this->info('All done!');
     }

--- a/app/Hyde/Actions/GetMarkdownPostList.php
+++ b/app/Hyde/Actions/GetMarkdownPostList.php
@@ -2,6 +2,8 @@
 
 namespace App\Hyde\Actions;
 
+use App\Hyde\Hyde;
+
 /**
  * Creates and returns a list of markdown paths
  * @deprecated as it will be moved into a static method in the post class
@@ -15,7 +17,7 @@ class GetMarkdownPostList
     {
         $array = [];
 
-        foreach (glob(base_path('_posts/*.md')) as $filepath) {
+        foreach (glob(Hyde::path('_posts/*.md')) as $filepath) {
             $array[basename($filepath, '.md')] = $filepath;
         }
 

--- a/app/Hyde/Actions/MarkdownConverter.php
+++ b/app/Hyde/Actions/MarkdownConverter.php
@@ -33,9 +33,9 @@ class MarkdownConverter
         if (Hyde::hasTorchlight()
             && config('torchlight.attribution', true)
             && str_contains($html, 'Syntax highlighted by torchlight.dev')) {
-            $html .= file_get_contents(realpath('src/resources/stubs') . DIRECTORY_SEPARATOR . 'torchlight-badge.html');
+            $html .= file_get_contents(Hyde::path('src/resources/stubs/torchlight-badge.html'));
         }
-
+        
         return $html;
     }
 }

--- a/app/Hyde/DocumentationPageParser.php
+++ b/app/Hyde/DocumentationPageParser.php
@@ -2,6 +2,7 @@
 
 namespace App\Hyde;
 
+use App\Hyde\Hyde;
 use App\Hyde\Models\DocumentationPage;
 use JetBrains\PhpStorm\NoReturn;
 use JetBrains\PhpStorm\Pure;
@@ -26,6 +27,10 @@ class DocumentationPageParser
      */
     public string $body;
 
+    /**
+     * The page title
+     * @var string
+     */
     public string $title;
 
     /**
@@ -35,7 +40,7 @@ class DocumentationPageParser
      */
     public function __construct(protected string $slug)
     {
-        $this->filepath = realpath('./_docs') . "/$slug.md";
+        $this->filepath = Hyde::path("_docs/$slug.md");
         if (!file_exists($this->filepath)) {
             throw new Exception("File _docs/$slug.md not found.", 404);
         }

--- a/app/Hyde/Features.php
+++ b/app/Hyde/Features.php
@@ -22,7 +22,7 @@ class Features
     }
 
 
-	/**
+    /**
      * Determine if the site has blog posts enabled.
      *
      * @return bool
@@ -32,7 +32,7 @@ class Features
         return static::enabled(static::blogPosts());
     }
 
-	/**
+    /**
      * Determine if the site has custom Blade pages enabled.
      *
      * @return bool
@@ -42,7 +42,7 @@ class Features
         return static::enabled(static::bladePages());
     }
 
-	/**
+    /**
      * Determine if the site has custom Markdown pages enabled.
      *
      * @return bool
@@ -52,7 +52,7 @@ class Features
         return static::enabled(static::markdownPages());
     }
 
-	/**
+    /**
      * Determine if the site has Laradocgen enabled.
      *
      * @return bool
@@ -63,7 +63,7 @@ class Features
     }
 
 
-	/**
+    /**
      * Enable the blog post feature.
      *
      * @return string
@@ -73,7 +73,7 @@ class Features
         return 'blog-posts';
     }
 
-	/**
+    /**
      * Enable the Blade page feature.
      *
      * @return string
@@ -83,7 +83,7 @@ class Features
         return 'blade-pages';
     }
 
-	/**
+    /**
      * Enable the Markdown page feature.
      *
      * @return string
@@ -93,7 +93,7 @@ class Features
         return 'markdown-pages';
     }
 
-	/**
+    /**
      * Enable the documentation page feature.
      *
      * @return string
@@ -102,5 +102,4 @@ class Features
     {
         return 'documentation-pages';
     }
-
 }

--- a/app/Hyde/Hyde.php
+++ b/app/Hyde/Hyde.php
@@ -18,4 +18,26 @@ class Hyde
     {
         return (config('torchlight.token') !== null);
     }
+
+    /**
+     * Get an absolute path from a supplied relative path.
+     *
+     * The function returns the fully qualified path to your site's root directory.
+     * 
+     * You may also use the function to generate a fully qualified path to a given file
+     * relative to the project root directory when supplying the path argument.
+     *
+     * @param string $path
+     * @return string
+     */
+    public static function path(string $path = ''): string
+    {
+        if (empty($path)) {
+            return getcwd();
+        }
+
+        $path = trim($path, '/\\');
+
+        return getcwd() . DIRECTORY_SEPARATOR . $path;
+    }
 }

--- a/app/Hyde/Hyde.php
+++ b/app/Hyde/Hyde.php
@@ -23,7 +23,7 @@ class Hyde
      * Get an absolute path from a supplied relative path.
      *
      * The function returns the fully qualified path to your site's root directory.
-     * 
+     *
      * You may also use the function to generate a fully qualified path to a given file
      * relative to the project root directory when supplying the path argument.
      *

--- a/app/Hyde/MarkdownPageParser.php
+++ b/app/Hyde/MarkdownPageParser.php
@@ -2,11 +2,12 @@
 
 namespace App\Hyde;
 
+use App\Hyde\Hyde;
 use App\Hyde\Models\MarkdownPage;
-use Exception;
 use JetBrains\PhpStorm\ArrayShape;
 use JetBrains\PhpStorm\NoReturn;
 use JetBrains\PhpStorm\Pure;
+use Exception;
 
 /**
  * Parses a Markdown file into an object with support for Front Matter.
@@ -39,7 +40,7 @@ class MarkdownPageParser
      */
     public function __construct(protected string $slug)
     {
-        $this->filepath = realpath('./_pages') . "/$slug.md";
+        $this->filepath = Hyde::path("_pages/$slug.md");
         if (!file_exists($this->filepath)) {
             throw new Exception("File _pages/$slug.md not found.", 404);
         }

--- a/app/Hyde/MarkdownPostParser.php
+++ b/app/Hyde/MarkdownPostParser.php
@@ -2,11 +2,12 @@
 
 namespace App\Hyde;
 
+use App\Hyde\Hyde;
 use App\Hyde\Models\MarkdownPost;
-use Exception;
 use JetBrains\PhpStorm\ArrayShape;
 use JetBrains\PhpStorm\NoReturn;
 use JetBrains\PhpStorm\Pure;
+use Exception;
 
 /**
  * Parses a Markdown file into an object with support for Front Matter.
@@ -39,7 +40,7 @@ class MarkdownPostParser
      */
     public function __construct(protected string $slug)
     {
-        $this->filepath = realpath('./_posts') . "/$slug.md";
+        $this->filepath = Hyde::path("_posts/$slug.md");
         if (!file_exists($this->filepath)) {
             throw new Exception("File _posts/$slug.md not found.", 404);
         }

--- a/app/Hyde/Models/DocumentationPage.php
+++ b/app/Hyde/Models/DocumentationPage.php
@@ -2,6 +2,8 @@
 
 namespace App\Hyde\Models;
 
+use App\Hyde\Hyde;
+
 /**
  * A simple class that contains the content of a Documentation Page.
  */
@@ -47,7 +49,7 @@ class DocumentationPage
     {
         $array = [];
 
-        foreach (glob(base_path('_docs/*.md')) as $filepath) {
+        foreach (glob(Hyde::path('_docs/*.md')) as $filepath) {
             $array[basename($filepath, '.md')] = $filepath;
         }
 

--- a/app/Hyde/Models/MarkdownPage.php
+++ b/app/Hyde/Models/MarkdownPage.php
@@ -2,6 +2,8 @@
 
 namespace App\Hyde\Models;
 
+use App\Hyde\Hyde;
+
 /**
  * A simple class that contains the content of a basic Markdown Page.
  */
@@ -48,7 +50,7 @@ class MarkdownPage
     {
         $array = [];
 
-        foreach (glob(base_path('_pages/*.md')) as $filepath) {
+        foreach (glob(Hyde::path('_pages/*.md')) as $filepath) {
             $array[basename($filepath, '.md')] = $filepath;
         }
 

--- a/app/Hyde/Models/MarkdownPost.php
+++ b/app/Hyde/Models/MarkdownPost.php
@@ -2,6 +2,7 @@
 
 namespace App\Hyde\Models;
 
+use App\Hyde\Hyde;
 use App\Hyde\MarkdownPostParser;
 use Illuminate\Support\Collection;
 
@@ -50,7 +51,7 @@ class MarkdownPost
     {
         $collection = new Collection();
 
-        foreach (glob(base_path('_posts/*.md')) as $filepath) {
+        foreach (glob(Hyde::path('_posts/*.md')) as $filepath) {
             $collection->push((new MarkdownPostParser(basename($filepath, '.md')))->get());
         }
 

--- a/app/Hyde/Services/CollectionService.php
+++ b/app/Hyde/Services/CollectionService.php
@@ -2,6 +2,7 @@
 
 namespace App\Hyde\Services;
 
+use App\Hyde\Hyde;
 use App\Hyde\Models\BladePage;
 use App\Hyde\Models\MarkdownPage;
 use App\Hyde\Models\MarkdownPost;
@@ -47,7 +48,7 @@ class CollectionService
     {
         $array = [];
 
-        foreach (glob(base_path('resources/views/pages/*.blade.php')) as $filepath) {
+        foreach (glob(Hyde::path('resources/views/pages/*.blade.php')) as $filepath) {
             $array[] = basename($filepath, '.blade.php');
         }
 
@@ -62,7 +63,7 @@ class CollectionService
     {
         $array = [];
 
-        foreach (glob(base_path('_pages/*.md')) as $filepath) {
+        foreach (glob(Hyde::path('_pages/*.md')) as $filepath) {
             $array[] = basename($filepath, '.md');
         }
 
@@ -77,7 +78,7 @@ class CollectionService
     {
         $array = [];
 
-        foreach (glob(base_path('_posts/*.md')) as $filepath) {
+        foreach (glob(Hyde::path('_posts/*.md')) as $filepath) {
             $array[] = basename($filepath, '.md');
         }
 
@@ -93,7 +94,7 @@ class CollectionService
     {
         $array = [];
 
-        foreach (glob(base_path('_docs/*.md')) as $filepath) {
+        foreach (glob(Hyde::path('_docs/*.md')) as $filepath) {
             $array[] = basename($filepath, '.md');
         }
 

--- a/app/Hyde/StaticPageBuilder.php
+++ b/app/Hyde/StaticPageBuilder.php
@@ -73,7 +73,7 @@ class StaticPageBuilder
         return [
             'createdFileSize' => $this->createdFileSize,
             'createdFilePath' => $relativeFilePath
-                ? str_replace(base_path(), '', $this->createdFilePath)
+                ? str_replace(Hyde::path(), '', $this->createdFilePath)
                 : $this->createdFilePath ,
         ];
     }
@@ -85,7 +85,7 @@ class StaticPageBuilder
      */
     private function save(string $location, string $contents): bool|int
     {
-        $path = base_path('./_site') . '/' . $location . '.html';
+        $path = Hyde::path("_site/$location.html");
         $this->createdFilePath = $path;
         return file_put_contents($path, $contents);
     }

--- a/tests/Feature/Commands/MakePostCommandTest.php
+++ b/tests/Feature/Commands/MakePostCommandTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature\Commands;
 
+use App\Hyde\Hyde;
 use Tests\TestCase;
 
 class MakePostCommandTest extends TestCase
@@ -13,7 +14,7 @@ class MakePostCommandTest extends TestCase
      */
     public function getPath(): string
     {
-        return realpath('./_posts') . '/test-post.md';
+        return Hyde::path('_posts/test-post.md');
     }
 
     /**

--- a/tests/Feature/Commands/Publish404PageCommandTest.php
+++ b/tests/Feature/Commands/Publish404PageCommandTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature\Commands;
 
+use App\Hyde\Hyde;
 use Tests\TestCase;
 
 class Publish404PageCommandTest extends TestCase
@@ -40,12 +41,12 @@ class Publish404PageCommandTest extends TestCase
 
 	private function getBladePath(): string
 	{
-		return realpath('resources/views/pages') . DIRECTORY_SEPARATOR . '404.blade.php';
+		return Hyde::path('resources/views/pages/404.blade.php');
 	}
 
 	private function getMarkdownPath(): string
 	{
-		return realpath('_pages') . DIRECTORY_SEPARATOR . '404.md';
+		return Hyde::path('_pages/404.md');
 	}
 
     public function test_command_exists()

--- a/tests/Feature/InspireCommandTest.php
+++ b/tests/Feature/InspireCommandTest.php
@@ -1,5 +1,0 @@
-<?php
-
-it('inspire artisans', function () {
-    $this->artisan('inspire')->assertExitCode(0);
-});

--- a/tests/Unit/CreatesDefaultDirectoriesTest.php
+++ b/tests/Unit/CreatesDefaultDirectoriesTest.php
@@ -4,6 +4,7 @@ namespace Tests\Unit;
 
 use PHPUnit\Framework\TestCase;
 use App\Actions\CreatesDefaultDirectories;
+use App\Hyde\Hyde;
 
 class CreatesDefaultDirectoriesTest extends TestCase
 {
@@ -22,7 +23,7 @@ class CreatesDefaultDirectoriesTest extends TestCase
     public function testDefaultDirectoriesAreCreated()
     {
         foreach (CreatesDefaultDirectories::getRequiredDirectories() as $directory) {
-            $this->assertTrue(is_dir(realpath("./$directory")));
+            $this->assertTrue(is_dir(Hyde::path($directory)));
         }
     }
 }

--- a/tests/Unit/ExampleTest.php
+++ b/tests/Unit/ExampleTest.php
@@ -1,5 +1,0 @@
-<?php
-
-test('example', function () {
-    expect(true)->toBeTrue();
-});

--- a/tests/Unit/HydePathHelperTest.php
+++ b/tests/Unit/HydePathHelperTest.php
@@ -15,7 +15,7 @@ test('string is returned', function () {
 test('returned directory contains content expected to be in the project directory',
     function () {
         expect(
-            file_exists(Hyde::path() . DIRECTORY_SEPARATOR . 'hyde') &&
+            file_exists(Hyde::path() . DIRECTORY_SEPARATOR . 'hyde')   &&
             file_exists(Hyde::path() . DIRECTORY_SEPARATOR . '_pages') &&
             file_exists(Hyde::path() . DIRECTORY_SEPARATOR . '_posts') &&
             file_exists(Hyde::path() . DIRECTORY_SEPARATOR . '_site')

--- a/tests/Unit/HydePathTest.php
+++ b/tests/Unit/HydePathTest.php
@@ -1,0 +1,46 @@
+<?php
+
+// Unit test the Hyde::path() helper
+
+use App\Hyde\Hyde;
+
+test('method exists', function () {
+    expect(method_exists(Hyde::class, 'path'))->toBeTrue();
+});
+
+test('string is returned', function () {
+    expect(Hyde::path())->toBeString();
+});
+
+test('returned directory contains content expected to be in the project directory',
+    function () {
+        expect(
+            file_exists(Hyde::path() . DIRECTORY_SEPARATOR . 'hyde') &&
+            file_exists(Hyde::path() . DIRECTORY_SEPARATOR . '_pages') &&
+            file_exists(Hyde::path() . DIRECTORY_SEPARATOR . '_posts') &&
+            file_exists(Hyde::path() . DIRECTORY_SEPARATOR . '_site')
+        )->toBeTrue();
+    }
+);
+
+test('method returns qualified file path when supplied with argument', function () {
+    expect(Hyde::path('file.php'))->toEqual(Hyde::path() . DIRECTORY_SEPARATOR . 'file.php');
+});
+
+test('method strips trailing directory separators from argument', function () {
+    expect(Hyde::path('\\/file.php/'))->toEqual(Hyde::path() . DIRECTORY_SEPARATOR . 'file.php');
+});
+
+test('method returns expected value for nested path arguments', function () {
+    expect(Hyde::path('directory/file.php'))
+        ->toEqual(Hyde::path() . DIRECTORY_SEPARATOR . 'directory/file.php');
+});
+
+test('method returns expected value regardless of trailing directory separators in argument', function () {
+    expect(Hyde::path('directory/file.php/'))
+        ->toEqual(Hyde::path() . DIRECTORY_SEPARATOR . 'directory/file.php');
+    expect(Hyde::path('/directory/file.php/'))
+        ->toEqual(Hyde::path() . DIRECTORY_SEPARATOR . 'directory/file.php');
+    expect(Hyde::path('\\/directory/file.php/'))
+        ->toEqual(Hyde::path() . DIRECTORY_SEPARATOR . 'directory/file.php');
+});

--- a/tests/Unit/MarkdownPostParserTest.php
+++ b/tests/Unit/MarkdownPostParserTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit;
 
+use App\Hyde\Hyde;
 use App\Hyde\MarkdownPostParser;
 use App\Hyde\Models\MarkdownPost;
 use PHPUnit\Framework\TestCase;
@@ -17,7 +18,7 @@ class MarkdownPostParserTest extends TestCase
         parent::setUp();
 
 		// Create a Markdown file to work with
-		copy(realpath('./tests') . '/_stubs/_posts/test-parser-post.md', $this->getPath());
+		copy(Hyde::path('tests/_stubs/_posts/test-parser-post.md'), $this->getPath());
 	}
 
     /**
@@ -39,7 +40,7 @@ class MarkdownPostParserTest extends TestCase
      */
     public function getPath(): string
     {
-        return realpath('./_posts') . '/test-parser-post.md';
+        return Hyde::path('_posts/test-parser-post.md');
     }
 
 	public function testCanParseMarkdownFile()
@@ -47,9 +48,19 @@ class MarkdownPostParserTest extends TestCase
 		$post = (new MarkdownPostParser('test-parser-post'))->get();
 		$this->assertInstanceOf(MarkdownPost::class, $post);
 		$this->assertCount(4, ($post->matter));
+		$this->assertIsArray($post->matter);
 		$this->assertIsString($post->body);
 		$this->assertIsString($post->slug);
 		$this->assertTrue(strlen($post->body) > 32);
 		$this->assertTrue(strlen($post->slug) > 8);
+	}
+    
+	public function testParsedMarkdownPostContainsValidFrontMatter()
+	{
+		$post = (new MarkdownPostParser('test-parser-post'))->get();
+        $this->assertEquals('My New Post', $post->matter['title']);
+        $this->assertEquals('Mr. Hyde', $post->matter['author']);
+        $this->assertEquals('blog', $post->matter['category']);
+        $this->assertEquals('test-parser-post', $post->matter['slug']);
 	}
 }

--- a/tests/Validators/CheckIfA404PageExistsTest.php
+++ b/tests/Validators/CheckIfA404PageExistsTest.php
@@ -1,8 +1,10 @@
 <?php
 
+use App\Hyde\Hyde;
+
 test('check if a 404 page exists', function () {
-    $assertion = file_exists(realpath('_pages/404.md'))
-    || file_exists(realpath('resources/views/pages/404.blade.php'));
+    $assertion = file_exists(Hyde::path('_pages/404.md'))
+    || file_exists(Hyde::path('resources/views/pages/404.blade.php'));
 
     if (!$assertion) {
     $this->addWarning('Could not find an 404.md or 404.blade.php file! You can scaffold one using `php hyde publish:404`'); 

--- a/tests/Validators/CheckThatAnIndexFileExistsTest.php
+++ b/tests/Validators/CheckThatAnIndexFileExistsTest.php
@@ -1,8 +1,10 @@
 <?php
 
+use App\Hyde\Hyde;
+
 test('check that an index file exists', function () {
-     $assertion = file_exists(realpath('_pages/index.md'))
-               || file_exists(realpath('resources/views/pages/index.blade.php'));
+     $assertion = file_exists(Hyde::path('_pages/index.md'))
+               || file_exists(Hyde::path('resources/views/pages/index.blade.php'));
 
     if (!$assertion) {
         $this->addWarning('Could not find an index.md or index.blade.php file!'); 


### PR DESCRIPTION
Up until now we have been referencing files using a few different method. This PR unifies those calls to a new single method, namely `Hyde::path()`