### PR TITLE
Update command class names

### DIFF
--- a/config/commands.php
+++ b/config/commands.php
@@ -62,9 +62,9 @@ return [
         Illuminate\Console\Scheduling\ScheduleListCommand::class,
         Illuminate\Console\Scheduling\ScheduleFinishCommand::class,
         LaravelZero\Framework\Commands\StubPublishCommand::class,
-        Hyde\Framework\Commands\MakeValidatorCommand::class,
-        Hyde\Framework\Commands\PublishStubsCommand::class,
-        Hyde\Framework\Commands\Debug::class,
+        Hyde\Framework\Commands\HydeMakeValidatorCommand::class,
+        Hyde\Framework\Commands\HydePublishStubsCommand::class,
+        Hyde\Framework\Commands\HydeDebugCommand::class,
     ],
 
     /*

--- a/tests/Unit/EnsureCommandsFollowNamingConventionTest.php
+++ b/tests/Unit/EnsureCommandsFollowNamingConventionTest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Tests\Unit;
+
+use Hyde\Framework\Hyde;
+use PHPUnit\Framework\TestCase;
+
+class EnsureCommandsFollowNamingConventionTest extends TestCase
+{
+    public function test_ensure_commands_follow_naming_convention()
+    {
+        foreach (glob(Hyde::path('vendor/hyde/framework/src/commands/*.php')) as $filepath) {
+            $filename = basename($filepath, '.php');
+            $this->assertStringStartsWith('Hyde', $filename);
+            $this->assertStringEndsWith('Command', $filename);
+        }
+    }
+}


### PR DESCRIPTION
Updates to Framework PR #32 by updating the command config and add unit test

For end-users this causes no notable change, though the config/commands.php file needs to be updated.