### PR TITLE
Add SASS as a dev dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hydefront",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1793,6 +1793,25 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
+    },
+    "sass": {
+      "version": "1.49.10",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.49.10.tgz",
+      "integrity": "sha512-w37zfWJwKu4I78U4z63u1mmgoncq+v3iOB4yzQMPyAPVHHawaQSnu9C9ysGQnZEhW609jkcLioJcMCqm75JMdg==",
+      "dev": true,
+      "requires": {
+        "chokidar": ">=3.0.0 <4.0.0",
+        "immutable": "^4.0.0",
+        "source-map-js": ">=0.6.2 <2.0.0"
+      },
+      "dependencies": {
+        "immutable": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.0.0.tgz",
+          "integrity": "sha512-zIE9hX70qew5qTUjSS7wi1iwj/l7+m54KWU247nhM3v806UdGj1yDndXj+IOYxxtW9zyLI+xqFNZjTuDaLUqFw==",
+          "dev": true
+        }
+      }
     },
     "send": {
       "version": "0.16.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hydefront",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Frontend assets for HydePHP",
   "main": "_site/index.html",
   "directories": {
@@ -40,6 +40,7 @@
     "chokidar-cli": "^3.0.0",
     "concurrently": "^7.0.0",
     "prettier": "2.6.0",
+    "sass": "^1.49.10",
     "tailwindcss": "^3.0.23"
   }
 }


### PR DESCRIPTION
Adds the Node version of SASS as a dev dependency to be compatible with systems that do not have Dart SASS installed.

Updates hydefront to 0.2.0.