### PR TITLE
Internal build service refactor tie in

### DIFF
--- a/config/commands.php
+++ b/config/commands.php
@@ -58,11 +58,6 @@ return [
         NunoMaduro\LaravelConsoleSummary\SummaryCommand::class,
         Symfony\Component\Console\Command\DumpCompletionCommand::class,
         Symfony\Component\Console\Command\HelpCommand::class,
-        Illuminate\Console\Scheduling\ScheduleRunCommand::class,
-        Illuminate\Console\Scheduling\ScheduleListCommand::class,
-        Illuminate\Console\Scheduling\ScheduleFinishCommand::class,
-        LaravelZero\Framework\Commands\StubPublishCommand::class,
-        Hyde\Framework\Commands\HydePublishStubsCommand::class,
         Hyde\Framework\Commands\HydeDebugCommand::class,
     ],
 
@@ -79,6 +74,10 @@ return [
 
     'remove' => [
         Illuminate\Console\Scheduling\ScheduleRunCommand::class,
+        Illuminate\Console\Scheduling\ScheduleListCommand::class,
+        Illuminate\Console\Scheduling\ScheduleFinishCommand::class,
+        Illuminate\Console\Scheduling\ScheduleRunCommand::class,
+        LaravelZero\Framework\Commands\StubPublishCommand::class,
     ],
 
 ];

--- a/config/commands.php
+++ b/config/commands.php
@@ -62,7 +62,6 @@ return [
         Illuminate\Console\Scheduling\ScheduleListCommand::class,
         Illuminate\Console\Scheduling\ScheduleFinishCommand::class,
         LaravelZero\Framework\Commands\StubPublishCommand::class,
-        Hyde\Framework\Commands\HydeMakeValidatorCommand::class,
         Hyde\Framework\Commands\HydePublishStubsCommand::class,
         Hyde\Framework\Commands\HydeDebugCommand::class,
     ],

--- a/tests/Feature/AuthorServiceTest.php
+++ b/tests/Feature/AuthorServiceTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\TestCase;
 
 class AuthorServiceTest extends TestCase
 {
-    public function testPublishFileCreatesFile()
+    public function test_publish_file_creates_file()
     {
         $service = new AuthorService();
         $path = $service->filepath;
@@ -22,7 +22,7 @@ class AuthorServiceTest extends TestCase
         $this->assertFileExists($path);
     }
 
-    public function testGetAuthorsReturnsAuthorCollection()
+    public function test_get_authors_returns_author_collection()
     {
         $service = new AuthorService();
         $service->publishFile();
@@ -40,7 +40,7 @@ class AuthorServiceTest extends TestCase
         $this->assertEquals('https://github.com/hydephp/hyde', $author->website);
     }
 
-    public function testCanFindAuthorByUsername()
+    public function test_can_find_author_by_username()
     {
         $service = new AuthorService();
         $service->publishFile();
@@ -54,7 +54,7 @@ class AuthorServiceTest extends TestCase
         $this->assertEquals('https://github.com/hydephp/hyde', $author->website);
     }
 
-    public function testGetYamlCanParseFile()
+    public function test_get_yaml_can_parse_file()
     {
         $service = new AuthorService();
 

--- a/tests/Feature/BuildServiceTest.php
+++ b/tests/Feature/BuildServiceTest.php
@@ -2,10 +2,82 @@
 
 namespace Tests\Feature;
 
+use Hyde\Framework\DocumentationPageParser;
+use Hyde\Framework\MarkdownPageParser;
+use Hyde\Framework\MarkdownPostParser;
+use Hyde\Framework\Models\BladePage;
+use Hyde\Framework\Models\DocumentationPage;
+use Hyde\Framework\Models\MarkdownPage;
+use Hyde\Framework\Models\MarkdownPost;
 use Hyde\Framework\Services\BuildService;
+use Tests\Setup\MockContentSourceFiles;
 use Tests\TestCase;
 
 class BuildServiceTest extends TestCase
 {
-  
+    use MockContentSourceFiles;
+
+    public function testFindModelFromFilePath()
+    {
+        $this->assertEquals(MarkdownPost::class, BuildService::findModelFromFilePath('_posts/test.md'));
+        $this->assertEquals(MarkdownPage::class, BuildService::findModelFromFilePath('_pages/test.md'));
+        $this->assertEquals(DocumentationPage::class, BuildService::findModelFromFilePath('_docs/test.md'));
+        $this->assertEquals(BladePage::class, BuildService::findModelFromFilePath('resources/views/pages/test.md'));
+
+        $this->assertFalse(BuildService::findModelFromFilePath('foo/bar/test.md'));
+    }
+
+    public function testGetParserClassForModel()
+    {
+        $this->assertEquals(MarkdownPageParser::class, BuildService::getParserClassForModel(MarkdownPage::class));
+        $this->assertEquals(MarkdownPostParser::class, BuildService::getParserClassForModel(MarkdownPost::class));
+        $this->assertEquals(DocumentationPageParser::class, BuildService::getParserClassForModel(DocumentationPage::class));
+        $this->assertEquals(BladePage::class, BuildService::getParserClassForModel(BladePage::class));
+
+        $this->assertFalse(BuildService::getParserClassForModel('foo/bar'));
+    }
+
+    public function testGetParserInstanceForModel()
+    {
+        $this->createContentSourceTestFiles();
+
+        $this->assertInstanceOf(MarkdownPageParser::class, BuildService::getParserInstanceForModel(MarkdownPage::class, 'test'));
+        $this->assertInstanceOf(MarkdownPostParser::class, BuildService::getParserInstanceForModel(MarkdownPost::class, 'test'));
+        $this->assertInstanceOf(DocumentationPageParser::class, BuildService::getParserInstanceForModel(DocumentationPage::class, 'test'));
+        $this->assertInstanceOf(BladePage::class, BuildService::getParserInstanceForModel(BladePage::class, 'test'));
+
+        $this->assertFalse(BuildService::getParserInstanceForModel('foo/bar', 'test'));
+
+        $this->deleteContentSourceTestFiles();
+    }
+
+    public function testGetFileExtensionForModelFiles()
+    {
+        $this->assertEquals('.md', BuildService::getFileExtensionForModelFiles(MarkdownPage::class));
+        $this->assertEquals('.md', BuildService::getFileExtensionForModelFiles(MarkdownPost::class));
+        $this->assertEquals('.md', BuildService::getFileExtensionForModelFiles(DocumentationPage::class));
+        $this->assertEquals('.blade.php', BuildService::getFileExtensionForModelFiles(BladePage::class));
+
+        $this->assertFalse(BuildService::getFileExtensionForModelFiles('foo/bar'));
+    }
+
+    public function testGetFilePathForModelClassFiles()
+    {
+        $this->assertEquals('_posts', BuildService::getFilePathForModelClassFiles(MarkdownPost::class));
+        $this->assertEquals('_pages', BuildService::getFilePathForModelClassFiles(MarkdownPage::class));
+        $this->assertEquals('_docs', BuildService::getFilePathForModelClassFiles(DocumentationPage::class));
+        $this->assertEquals('resources/views/pages', BuildService::getFilePathForModelClassFiles(BladePage::class));
+
+        $this->assertFalse(BuildService::getFilePathForModelClassFiles('foo/bar'));
+    }
+
+    public function testCreateClickableFilepath()
+    {
+        $filename = 'be2329d7-3596-48f4-b5b8-deff352246a9';
+        touch($filename);
+        $output = BuildService::createClickableFilepath($filename);
+        $this->assertStringContainsString('file://', $output);
+        $this->assertStringContainsString($filename, $output);
+        unlink($filename);
+    }
 }

--- a/tests/Feature/BuildServiceTest.php
+++ b/tests/Feature/BuildServiceTest.php
@@ -2,96 +2,10 @@
 
 namespace Tests\Feature;
 
-use Exception;
-use Hyde\Framework\Hyde;
 use Hyde\Framework\Services\BuildService;
-use Hyde\Framework\StaticPageBuilder;
 use Tests\TestCase;
 
-/**
- * Note that we don't actually test if the files were created,
- * since the service is just a proxy for the actual builders,
- * which have their own tests that include this feature.
- */
 class BuildServiceTest extends TestCase
 {
-    /** @throws Exception */
-    public function testDetermineModelCanFindMarkdownPost()
-    {
-        $service = new BuildService('_posts/test.md');
-        $result = $service->determineModel();
-        $this->assertEquals('Hyde\Framework\Models\MarkdownPost', $result);
-    }
-
-    /** @throws Exception */
-    public function testDetermineModelCanFindMarkdownPage()
-    {
-        $service = new BuildService('_pages/test.md');
-        $result = $service->determineModel();
-        $this->assertEquals('Hyde\Framework\Models\MarkdownPage', $result);
-    }
-
-    /** @throws Exception */
-    public function testDetermineModelCanFindDocumentationPage()
-    {
-        $service = new BuildService('_docs/test.md');
-        $result = $service->determineModel();
-        $this->assertEquals('Hyde\Framework\Models\DocumentationPage', $result);
-    }
-
-    /** @throws Exception */
-    public function testDetermineModelCanFindBladePage()
-    {
-        $service = new BuildService('resources/views/pages/test.md');
-        $result = $service->determineModel();
-        $this->assertEquals('Hyde\Framework\Models\BladePage', $result);
-    }
-
-    public function testDetermineModelThrowsExceptionWhenSuppliedWithUnknownPath()
-    {
-        $service = new BuildService('foo/bar/test.md');
-        $this->expectException(Exception::class);
-        $this->expectExceptionMessage('Invalid source path.');
-        $this->expectExceptionCode(400);
-        $result = $service->determineModel();
-        $this->assertNull($result);
-    }
-
-    /** @throws Exception */
-    public function testExecute()
-    {
-        $path = '_posts/test-f01cae99-29ca-481e-b977-6acf9ee364d3.md';
-        copy(
-            Hyde::path('vendor/hyde/framework/tests/stubs/_posts/my-new-post.md'),
-            Hyde::path($path)
-        );
-        $service = new BuildService('_posts/test-f01cae99-29ca-481e-b977-6acf9ee364d3.md');
-        $service->execute();
-        $this->assertNotNull($service->model);
-        unlink(Hyde::path($path));
-    }
-
-    /** @throws Exception */
-    public function testHandle()
-    {
-        $this->runHandleTest('_posts');
-        $this->runHandleTest('_pages');
-        $this->runHandleTest('_docs');
-        $this->runHandleTest('resources/views/pages', '.blade.php');
-    }
-
-    /** @throws Exception */
-    private function runHandleTest(string $prefix, string $suffix = '.md')
-    {
-        $path = $prefix.'/test-f01cae99-29ca-481e-b977-6acf9ee364d3'.$suffix;
-        copy(
-            Hyde::path('vendor/hyde/framework/tests/stubs/_posts/my-new-post.md'),
-            Hyde::path($path)
-        );
-        $service = new BuildService($path);
-        $service->determineModel();
-        $result = $service->handle();
-        $this->assertInstanceOf(StaticPageBuilder::class, $result);
-        unlink(Hyde::path($path));
-    }
+  
 }

--- a/tests/Feature/BuildServiceTest.php
+++ b/tests/Feature/BuildServiceTest.php
@@ -17,7 +17,7 @@ class BuildServiceTest extends TestCase
 {
     use MockContentSourceFiles;
 
-    public function testFindModelFromFilePath()
+    public function test_find_model_from_file_path()
     {
         $this->assertEquals(MarkdownPost::class, BuildService::findModelFromFilePath('_posts/test.md'));
         $this->assertEquals(MarkdownPage::class, BuildService::findModelFromFilePath('_pages/test.md'));
@@ -27,7 +27,7 @@ class BuildServiceTest extends TestCase
         $this->assertFalse(BuildService::findModelFromFilePath('foo/bar/test.md'));
     }
 
-    public function testGetParserClassForModel()
+    public function test_get_parser_class_for_model()
     {
         $this->assertEquals(MarkdownPageParser::class, BuildService::getParserClassForModel(MarkdownPage::class));
         $this->assertEquals(MarkdownPostParser::class, BuildService::getParserClassForModel(MarkdownPost::class));
@@ -37,7 +37,7 @@ class BuildServiceTest extends TestCase
         $this->assertFalse(BuildService::getParserClassForModel('foo/bar'));
     }
 
-    public function testGetParserInstanceForModel()
+    public function test_get_parser_instance_for_model()
     {
         $this->createContentSourceTestFiles();
 
@@ -51,7 +51,7 @@ class BuildServiceTest extends TestCase
         $this->deleteContentSourceTestFiles();
     }
 
-    public function testGetFileExtensionForModelFiles()
+    public function test_get_file_extension_for_model_files()
     {
         $this->assertEquals('.md', BuildService::getFileExtensionForModelFiles(MarkdownPage::class));
         $this->assertEquals('.md', BuildService::getFileExtensionForModelFiles(MarkdownPost::class));
@@ -61,7 +61,7 @@ class BuildServiceTest extends TestCase
         $this->assertFalse(BuildService::getFileExtensionForModelFiles('foo/bar'));
     }
 
-    public function testGetFilePathForModelClassFiles()
+    public function test_get_file_path_for_model_class_files()
     {
         $this->assertEquals('_posts', BuildService::getFilePathForModelClassFiles(MarkdownPost::class));
         $this->assertEquals('_pages', BuildService::getFilePathForModelClassFiles(MarkdownPage::class));
@@ -71,7 +71,7 @@ class BuildServiceTest extends TestCase
         $this->assertFalse(BuildService::getFilePathForModelClassFiles('foo/bar'));
     }
 
-    public function testCreateClickableFilepath()
+    public function test_create_clickable_filepath()
     {
         $filename = 'be2329d7-3596-48f4-b5b8-deff352246a9';
         touch($filename);

--- a/tests/Feature/Commands/BuildStaticSiteCommandTest.php
+++ b/tests/Feature/Commands/BuildStaticSiteCommandTest.php
@@ -111,6 +111,34 @@ class BuildStaticSiteCommandTest extends TestCase
             ->assertExitCode(0);
     }
 
+    public function testHandleCleanOption()
+    {
+        $this->artisan('build --clean')
+            ->expectsOutput('The --clean option will remove all files in the output directory before building.')
+            ->expectsConfirmation('Are you sure?')
+            ->assertExitCode(1);
+    }
+
+    public function testHandlePurgeMethod()
+    {
+        touch(Hyde::path('_site/foo.html'));
+        $this->artisan('build --clean --force')
+            ->expectsOutput('Removing all files from build directory.')
+            ->expectsOutput(' > Directory purged')
+            ->expectsOutput(' > Recreating directories')
+            ->assertExitCode(0);
+        $this->assertFileDoesNotExist(Hyde::path('_site/foo.html'));
+    }
+
+    public function testNodeActionOutputs()
+    {
+        $this->artisan('build --pretty --run-dev --run-prod')
+            ->expectsOutput('Prettifying code! This may take a second.')
+            ->expectsOutput('Building frontend assets for development! This may take a second.')
+            ->expectsOutput('Building frontend assets for production! This may take a second.')
+            ->assertExitCode(0);
+    }
+
     private function checkIfDirectoryIsEmpty(string $directory): bool
     {
         $scan = scandir(Hyde::path($directory), SCANDIR_SORT_NONE);

--- a/tests/Feature/Commands/BuildStaticSiteCommandTest.php
+++ b/tests/Feature/Commands/BuildStaticSiteCommandTest.php
@@ -47,7 +47,7 @@ class BuildStaticSiteCommandTest extends TestCase
             ->expectsOutput('Transferring Media Assets...')
             ->expectsOutput('Creating Markdown Posts...')
             ->expectsOutput('No Documentation Pages found. Skipping...')
-            ->expectsOutput('Creating Custom Blade Pages...')
+            ->expectsOutput('Creating Blade Pages...')
             ->expectsOutputToContain('All done! Finished in')
             ->expectsOutput('Congratulations! 🎉 Your static site has been built!')
             ->expectsOutput('Your new homepage is stored here -> file://'.str_replace(

--- a/tests/Feature/Commands/BuildStaticSiteCommandTest.php
+++ b/tests/Feature/Commands/BuildStaticSiteCommandTest.php
@@ -50,11 +50,11 @@ class BuildStaticSiteCommandTest extends TestCase
             ->expectsOutput('Creating Blade Pages...')
             ->expectsOutputToContain('All done! Finished in')
             ->expectsOutput('Congratulations! 🎉 Your static site has been built!')
-            ->expectsOutput('Your new homepage is stored here -> file://'.str_replace(
+            ->expectsOutput('Your new homepage is stored here -> file://' . str_replace(
                 '\\',
                 '/',
                 realpath(Hyde::path('_site'))
-            ).'/index.html')
+            ) . '/index.html')
             ->assertExitCode(0);
     }
 
@@ -111,7 +111,14 @@ class BuildStaticSiteCommandTest extends TestCase
             ->assertExitCode(0);
     }
 
-    public function testHandleCleanOption()
+    public function test_print_initial_information_allows_api_to_be_disabled()
+    {
+        $this->artisan('build --no-api')
+            ->expectsOutput('Disabling external API calls')
+            ->assertExitCode(0);
+    }
+
+    public function test_handle_clean_option()
     {
         $this->artisan('build --clean')
             ->expectsOutput('The --clean option will remove all files in the output directory before building.')
@@ -124,7 +131,7 @@ class BuildStaticSiteCommandTest extends TestCase
             ->assertExitCode(0);
     }
 
-    public function testHandlePurgeMethod()
+    public function test_handle_purge_method()
     {
         touch(Hyde::path('_site/foo.html'));
         $this->artisan('build --clean --force')
@@ -135,7 +142,7 @@ class BuildStaticSiteCommandTest extends TestCase
         $this->assertFileDoesNotExist(Hyde::path('_site/foo.html'));
     }
 
-    public function testNodeActionOutputs()
+    public function test_node_action_outputs()
     {
         $this->artisan('build --pretty --run-dev --run-prod')
             ->expectsOutput('Prettifying code! This may take a second.')
@@ -148,7 +155,7 @@ class BuildStaticSiteCommandTest extends TestCase
     {
         $scan = scandir(Hyde::path($directory), SCANDIR_SORT_NONE);
         if ($scan) {
-            return ! isset($scan[2]);
+            return !isset($scan[2]);
         }
 
         return false;

--- a/tests/Feature/Commands/BuildStaticSiteCommandTest.php
+++ b/tests/Feature/Commands/BuildStaticSiteCommandTest.php
@@ -117,6 +117,11 @@ class BuildStaticSiteCommandTest extends TestCase
             ->expectsOutput('The --clean option will remove all files in the output directory before building.')
             ->expectsConfirmation('Are you sure?')
             ->assertExitCode(1);
+
+        $this->artisan('build --clean')
+            ->expectsOutput('The --clean option will remove all files in the output directory before building.')
+            ->expectsConfirmation('Are you sure?', 'yes')
+            ->assertExitCode(0);
     }
 
     public function testHandlePurgeMethod()

--- a/tests/Feature/Commands/HydePublishFrontendResourcesCommandTest.php
+++ b/tests/Feature/Commands/HydePublishFrontendResourcesCommandTest.php
@@ -19,7 +19,7 @@ class HydePublishFrontendResourcesCommandTest extends TestCase
     }
 
     /** @test */
-    public function testCommandReturnsZeroExitCode()
+    public function test_command_returns_zero_exit_code()
     {
         $this->artisan('update:resources --force')
             ->doesntExpectOutput('Please note that the following files will be overwritten:')
@@ -27,7 +27,7 @@ class HydePublishFrontendResourcesCommandTest extends TestCase
     }
 
     /** @test */
-    public function testCommandHasExpectedOutput()
+    public function test_command_has_expected_output()
     {
         $this->artisan('update:resources ')
             ->expectsOutput('Publishing frontend resources!')
@@ -37,7 +37,7 @@ class HydePublishFrontendResourcesCommandTest extends TestCase
     }
 
     /** @test */
-    public function testCommandHasCanPublishResources()
+    public function test_command_has_can_publish_resources()
     {
         $this->artisan('update:resources')
             ->expectsConfirmation('Would you like to continue?', 'yes')

--- a/tests/Feature/Commands/HydeRebuildStaticSiteCommandTest.php
+++ b/tests/Feature/Commands/HydeRebuildStaticSiteCommandTest.php
@@ -24,6 +24,12 @@ class HydeRebuildStaticSiteCommandTest extends TestCase
         unlink(Hyde::path($outputPath));
     }
 
+    public function testMediaFilesCanBeTransferred()
+    {
+        $this->artisan('rebuild _media')
+            ->assertExitCode(0);
+    }
+
     public function testValidateCatchesBadSourceDirectory()
     {
         $this->artisan('rebuild foo/bar')

--- a/tests/Feature/Commands/HydeRebuildStaticSiteCommandTest.php
+++ b/tests/Feature/Commands/HydeRebuildStaticSiteCommandTest.php
@@ -10,11 +10,11 @@ class HydeRebuildStaticSiteCommandTest extends TestCase
     public static string $stub = 'vendor/hyde/framework/tests/stubs/_posts/my-new-post.md';
     public static string $path = '_pages/test-07239181-403e-443b-94f3-f912a031f31a.md';
 
-    public function testHandleIsSuccessfulWithValidPath()
+    public function test_handle_is_successful_with_valid_path()
     {
         copy(Hyde::path(static::$stub), Hyde::path(static::$path));
 
-        $this->artisan('rebuild '.static::$path)
+        $this->artisan('rebuild ' . static::$path)
             ->assertExitCode(0);
 
         $outputPath = '_site/test-07239181-403e-443b-94f3-f912a031f31a.html';
@@ -24,20 +24,20 @@ class HydeRebuildStaticSiteCommandTest extends TestCase
         unlink(Hyde::path($outputPath));
     }
 
-    public function testMediaFilesCanBeTransferred()
+    public function test_media_files_can_be_transferred()
     {
         $this->artisan('rebuild _media')
             ->assertExitCode(0);
     }
 
-    public function testValidateCatchesBadSourceDirectory()
+    public function test_validate_catches_bad_source_directory()
     {
         $this->artisan('rebuild foo/bar')
             ->expectsOutput('Path [foo/bar] is not in a valid source directory.')
             ->assertExitCode(400);
     }
 
-    public function testValidateCatchesMissingFile()
+    public function test_validate_catches_missing_file()
     {
         $this->artisan('rebuild _pages/foo.md')
             ->expectsOutput('File [_pages/foo.md] not found.')

--- a/tests/Feature/MarkdownFileServiceTest.php
+++ b/tests/Feature/MarkdownFileServiceTest.php
@@ -19,7 +19,7 @@ class MarkdownFileServiceTest extends TestCase
         parent::setUp();
 
         // Create a Markdown file to work with
-        copy(Hyde::path('tests/_stubs/_posts/test-parser-post.md'), $this->getPath());
+        copy(Hyde::path('vendor/hyde/framework/tests/stubs/_posts/test-parser-post.md'), $this->getPath());
     }
 
     /**

--- a/tests/Feature/MarkdownFileServiceTest.php
+++ b/tests/Feature/MarkdownFileServiceTest.php
@@ -45,7 +45,7 @@ class MarkdownFileServiceTest extends TestCase
         return Hyde::path('_posts/test-parser-post.md');
     }
 
-    public function testCanParseMarkdownFile()
+    public function test_can_parse_markdown_file()
     {
         $document = (new MarkdownFileService(Hyde::path('_posts/test-parser-post.md')))->get();
         $this->assertInstanceOf(MarkdownDocument::class, $document);
@@ -62,7 +62,7 @@ class MarkdownFileServiceTest extends TestCase
         );
     }
 
-    public function testParsedMarkdownPostContainsValidFrontMatter()
+    public function test_parsed_markdown_post_contains_valid_front_matter()
     {
         $post = (new MarkdownFileService(Hyde::path('_posts/test-parser-post.md')))->get();
         $this->assertEquals('My New Post', $post->matter['title']);

--- a/tests/Feature/RebuildServiceTest.php
+++ b/tests/Feature/RebuildServiceTest.php
@@ -14,7 +14,7 @@ use Tests\TestCase;
  */
 class RebuildServiceTest extends TestCase
 {
-    public function testService()
+    public function test_service_method()
     {
         $path = '_posts/test-f01cae99-29ca-481e-b977-6acf9ee364d3.md';
         copy(
@@ -27,7 +27,7 @@ class RebuildServiceTest extends TestCase
         unlink(Hyde::path($path));
     }
 
-    public function testExecute()
+    public function test_execute_method()
     {
         $this->runExecuteTest('_posts');
         $this->runExecuteTest('_pages');

--- a/tests/Feature/RebuildServiceTest.php
+++ b/tests/Feature/RebuildServiceTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Tests\Feature;
+
+use Hyde\Framework\Hyde;
+use Hyde\Framework\Services\RebuildService;
+use Hyde\Framework\StaticPageBuilder;
+use Tests\TestCase;
+
+/**
+ * Note that we don't actually test if the files were created,
+ * since the service is just a proxy for the actual builders,
+ * which have their own tests that include this feature.
+ */
+class RebuildServiceTest extends TestCase
+{
+    public function testService()
+    {
+        $path = '_posts/test-f01cae99-29ca-481e-b977-6acf9ee364d3.md';
+        copy(
+            Hyde::path('vendor/hyde/framework/tests/stubs/_posts/my-new-post.md'),
+            Hyde::path($path)
+        );
+        $service = new RebuildService('_posts/test-f01cae99-29ca-481e-b977-6acf9ee364d3.md');
+        $service->execute();
+        $this->assertNotNull($service->model);
+        unlink(Hyde::path($path));
+    }
+
+    public function testExecute()
+    {
+        $this->runExecuteTest('_posts');
+        $this->runExecuteTest('_pages');
+        $this->runExecuteTest('_docs');
+        $this->runExecuteTest('resources/views/pages', '.blade.php');
+    }
+
+    private function runExecuteTest(string $prefix, string $suffix = '.md')
+    {
+        $path = $prefix.'/test-f01cae99-29ca-481e-b977-6acf9ee364d3'.$suffix;
+        copy(
+            Hyde::path('vendor/hyde/framework/tests/stubs/_posts/my-new-post.md'),
+            Hyde::path($path)
+        );
+        $service = new RebuildService($path);
+        $result = $service->execute();
+        $this->assertInstanceOf(StaticPageBuilder::class, $result);
+        unlink(Hyde::path($path));
+    }
+}

--- a/tests/Feature/Services/CollectionServiceTest.php
+++ b/tests/Feature/Services/CollectionServiceTest.php
@@ -22,12 +22,12 @@ class CollectionServiceTest extends TestCase
         // File::deleteDirectory(Hyde::path('_docs'));
     }
 
-    public function testClassExists()
+    public function test_class_exists()
     {
         $this->assertTrue(class_exists(CollectionService::class));
     }
 
-    public function testGetSourceFileListForModelMethod()
+    public function test_get_source_file_list_for_model_method()
     {
         $this->testListUnit(BladePage::class, 'resources/views/pages/a8a7b7ce.blade.php');
         $this->testListUnit(MarkdownPage::class, '_pages/a8a7b7ce.md');
@@ -37,7 +37,7 @@ class CollectionServiceTest extends TestCase
         $this->assertFalse(CollectionService::getSourceFileListForModel('NonExistentModel'));
     }
 
-    public function testGetMediaAssetFiles()
+    public function test_get_media_asset_files()
     {
         $this->assertTrue(is_array(CollectionService::getMediaAssetFiles()));
     }

--- a/tests/Feature/Services/CollectionServiceTest.php
+++ b/tests/Feature/Services/CollectionServiceTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Tests\Feature\Services;
+
+use Tests\TestCase;
+use Hyde\Framework\Hyde;
+use Hyde\Framework\Services\CollectionService;
+use Hyde\Framework\Models\BladePage;
+use Hyde\Framework\Models\MarkdownPage;
+use Hyde\Framework\Models\MarkdownPost;
+use Hyde\Framework\Models\DocumentationPage;
+use Illuminate\Support\Facades\File;
+use App\Commands\TestWithBackup;
+
+class CollectionServiceTest extends TestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        // TestWithBackup::backupDirectory(Hyde::path('_docs'));
+        // File::deleteDirectory(Hyde::path('_docs'));
+    }
+
+    public function testClassExists()
+    {
+        $this->assertTrue(class_exists(CollectionService::class));
+    }
+
+    public function testGetSourceFileListForModelMethod()
+    {
+        $this->testListUnit(BladePage::class, 'resources/views/pages/a8a7b7ce.blade.php');
+        $this->testListUnit(MarkdownPage::class, '_pages/a8a7b7ce.md');
+        $this->testListUnit(MarkdownPost::class, '_posts/a8a7b7ce.md');
+        $this->testListUnit(DocumentationPage::class, '_docs/a8a7b7ce.md');
+
+        $this->assertFalse(CollectionService::getSourceFileListForModel('NonExistentModel'));
+    }
+
+    public function testGetMediaAssetFiles()
+    {
+        $this->assertTrue(is_array(CollectionService::getMediaAssetFiles()));
+    }
+
+    private function testListUnit(string $model, string $path)
+    {
+        touch(Hyde::path($path));
+
+        $expected = str_replace(['.md', '.blade.php'], '', basename($path));
+
+        $this->assertContains($expected, CollectionService::getSourceFileListForModel($model));
+
+        unlink(Hyde::path($path));
+    }
+
+    public function tearDown(): void
+    {
+        // TestWithBackup::restoreDirectory(Hyde::path('_docs'));
+
+        parent::tearDown();
+    }
+}

--- a/tests/Setup/MockContentSourceFiles.php
+++ b/tests/Setup/MockContentSourceFiles.php
@@ -13,17 +13,17 @@ trait MockContentSourceFiles
 {
     public function createContentSourceTestFiles()
     {
-		touch(Hyde::path(BuildService::getFilePathForModelClassFiles(MarkdownPost::class) . '/test.md'));
-		touch(Hyde::path(BuildService::getFilePathForModelClassFiles(MarkdownPage::class) . '/test.md'));
-		touch(Hyde::path(BuildService::getFilePathForModelClassFiles(DocumentationPage::class) . '/test.md'));
-		touch(Hyde::path(BuildService::getFilePathForModelClassFiles(BladePage::class) . '/test.blade.php'));
+        touch(Hyde::path(BuildService::getFilePathForModelClassFiles(MarkdownPost::class) . '/test.md'));
+        touch(Hyde::path(BuildService::getFilePathForModelClassFiles(MarkdownPage::class) . '/test.md'));
+        touch(Hyde::path(BuildService::getFilePathForModelClassFiles(DocumentationPage::class) . '/test.md'));
+        touch(Hyde::path(BuildService::getFilePathForModelClassFiles(BladePage::class) . '/test.blade.php'));
     }
 
-	public function deleteContentSourceTestFiles()
-	{
-		unlink(Hyde::path(BuildService::getFilePathForModelClassFiles(MarkdownPost::class) . '/test.md'));
-		unlink(Hyde::path(BuildService::getFilePathForModelClassFiles(MarkdownPage::class) . '/test.md'));
-		unlink(Hyde::path(BuildService::getFilePathForModelClassFiles(DocumentationPage::class) . '/test.md'));
-		unlink(Hyde::path(BuildService::getFilePathForModelClassFiles(BladePage::class) . '/test.blade.php'));
-	}
+    public function deleteContentSourceTestFiles()
+    {
+        unlink(Hyde::path(BuildService::getFilePathForModelClassFiles(MarkdownPost::class) . '/test.md'));
+        unlink(Hyde::path(BuildService::getFilePathForModelClassFiles(MarkdownPage::class) . '/test.md'));
+        unlink(Hyde::path(BuildService::getFilePathForModelClassFiles(DocumentationPage::class) . '/test.md'));
+        unlink(Hyde::path(BuildService::getFilePathForModelClassFiles(BladePage::class) . '/test.blade.php'));
+    }
 }

--- a/tests/Setup/MockContentSourceFiles.php
+++ b/tests/Setup/MockContentSourceFiles.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Tests\Setup;
+
+use Hyde\Framework\Hyde;
+use Hyde\Framework\Models\MarkdownPost;
+use Hyde\Framework\Models\MarkdownPage;
+use Hyde\Framework\Models\DocumentationPage;
+use Hyde\Framework\Models\BladePage;
+use Hyde\Framework\Services\BuildService;
+
+trait MockContentSourceFiles
+{
+    public function createContentSourceTestFiles()
+    {
+		touch(Hyde::path(BuildService::getFilePathForModelClassFiles(MarkdownPost::class) . '/test.md'));
+		touch(Hyde::path(BuildService::getFilePathForModelClassFiles(MarkdownPage::class) . '/test.md'));
+		touch(Hyde::path(BuildService::getFilePathForModelClassFiles(DocumentationPage::class) . '/test.md'));
+		touch(Hyde::path(BuildService::getFilePathForModelClassFiles(BladePage::class) . '/test.blade.php'));
+    }
+
+	public function deleteContentSourceTestFiles()
+	{
+		unlink(Hyde::path(BuildService::getFilePathForModelClassFiles(MarkdownPost::class) . '/test.md'));
+		unlink(Hyde::path(BuildService::getFilePathForModelClassFiles(MarkdownPage::class) . '/test.md'));
+		unlink(Hyde::path(BuildService::getFilePathForModelClassFiles(DocumentationPage::class) . '/test.md'));
+		unlink(Hyde::path(BuildService::getFilePathForModelClassFiles(BladePage::class) . '/test.blade.php'));
+	}
+}

--- a/tests/Setup/ResetsFileEnvironment.php
+++ b/tests/Setup/ResetsFileEnvironment.php
@@ -11,7 +11,7 @@ trait ResetsFileEnvironment
 {
     public function resetFileEnvironment()
     {
-        Artisan::call('stubs:publish --clean --force');
+        Artisan::call('test:publish-stubs --clean --force');
         File::deleteDirectory(Hyde::path('_site'));
         (new CreatesDefaultDirectories)->__invoke();
     }

--- a/tests/Setup/RunDebugCommandTest.php
+++ b/tests/Setup/RunDebugCommandTest.php
@@ -6,6 +6,9 @@ use PHPUnit\Framework\TestCase;
 
 class RunDebugCommandTest extends TestCase
 {
+    /**
+     * This "test" prints the debug output and is run before all other tests.
+     */
     public function test_print_debug_info()
     {
         fwrite(STDOUT, (shell_exec('php hyde debug')));

--- a/tests/Unit/CreatesDefaultDirectoriesTest.php
+++ b/tests/Unit/CreatesDefaultDirectoriesTest.php
@@ -20,7 +20,7 @@ class CreatesDefaultDirectoriesTest extends TestCase
      *
      * @return void
      */
-    public function testDefaultDirectoriesAreCreated()
+    public function test_default_directories_are_created()
     {
         foreach (CreatesDefaultDirectories::getRequiredDirectories() as $directory) {
             $this->assertTrue(is_dir(Hyde::path($directory)));

--- a/tests/Unit/HydeSafeCopyHelperTest.php
+++ b/tests/Unit/HydeSafeCopyHelperTest.php
@@ -20,19 +20,19 @@ class HydeSafeCopyHelperTest extends TestCase
         mkdir(static::testDir());
     }
 
-    public function testCopyMethodExists()
+    public function test_copy_method_exists()
     {
         $this->assertTrue(method_exists(Hyde::class, 'copy'));
     }
 
-    public function testCopyMethodReturns404IfSourceFileDoesNotExist()
+    public function test_copy_method_returns404_if_source_file_does_not_exist()
     {
         $this->assertEquals(404,
             Hyde::copy(static::testDir('/does/not/exist.txt'), static::testDir('/test.txt'))
         );
     }
 
-    public function testCopyMethodReturns409IfDestinationFileExistsAndForceFlagIsNotSet()
+    public function test_copy_method_returns409_if_destination_file_exists_and_force_flag_is_not_set()
     {
         file_put_contents(static::testDir('/test.txt'), 'test');
 
@@ -43,7 +43,7 @@ class HydeSafeCopyHelperTest extends TestCase
         unlink(static::testDir('/test.txt'));
     }
 
-    public function testCopyMethodReturnsTrueIfDestinationFileExistsAndForceFlagIsSet()
+    public function test_copy_method_returns_true_if_destination_file_exists_and_force_flag_is_set()
     {
         file_put_contents(static::testDir('/foo.txt'), 'foo');
 
@@ -55,7 +55,7 @@ class HydeSafeCopyHelperTest extends TestCase
         unlink(static::testDir('/bar.txt'));
     }
 
-    public function testFileWithNoConflictsIsCopied()
+    public function test_file_with_no_conflicts_is_copied()
     {
         file_put_contents(static::testDir('/foo.txt'), 'foo');
 
@@ -66,7 +66,7 @@ class HydeSafeCopyHelperTest extends TestCase
         $this->assertFileExists(static::testDir('/bar.txt'));
     }
 
-    public function testFileWithConflictsIsNotCopiedWhenForceFlagIsNotSet()
+    public function test_file_with_conflicts_is_not_copied_when_force_flag_is_not_set()
     {
         file_put_contents(static::testDir('/foo.txt'), 'foo');
         file_put_contents(static::testDir('/bar.txt'), 'bar');
@@ -78,7 +78,7 @@ class HydeSafeCopyHelperTest extends TestCase
         $this->assertStringEqualsFile(static::testDir('/bar.txt'), 'bar');
     }
 
-    public function testFileWithConflictsIsCopiedWhenForceFlagIsSet()
+    public function test_file_with_conflicts_is_copied_when_force_flag_is_set()
     {
         file_put_contents(static::testDir('/foo.txt'), 'foo');
         file_put_contents(static::testDir('/bar.txt'), 'bar');

--- a/tests/Unit/HydeSafeCopyHelperTest.php
+++ b/tests/Unit/HydeSafeCopyHelperTest.php
@@ -27,7 +27,8 @@ class HydeSafeCopyHelperTest extends TestCase
 
     public function test_copy_method_returns404_if_source_file_does_not_exist()
     {
-        $this->assertEquals(404,
+        $this->assertEquals(
+            404,
             Hyde::copy(static::testDir('/does/not/exist.txt'), static::testDir('/test.txt'))
         );
     }
@@ -36,7 +37,8 @@ class HydeSafeCopyHelperTest extends TestCase
     {
         file_put_contents(static::testDir('/test.txt'), 'test');
 
-        $this->assertEquals(409,
+        $this->assertEquals(
+            409,
             Hyde::copy(static::testDir('/test.txt'), static::testDir('/test.txt'))
         );
 
@@ -71,7 +73,8 @@ class HydeSafeCopyHelperTest extends TestCase
         file_put_contents(static::testDir('/foo.txt'), 'foo');
         file_put_contents(static::testDir('/bar.txt'), 'bar');
 
-        $this->assertEquals(409,
+        $this->assertEquals(
+            409,
             Hyde::copy(static::testDir('/foo.txt'), static::testDir('/bar.txt'))
         );
 

--- a/tests/Unit/HydeUriPathHelperTest.php
+++ b/tests/Unit/HydeUriPathHelperTest.php
@@ -1,0 +1,20 @@
+<?php
+
+
+use Hyde\Framework\Hyde;
+use Tests\TestCase;
+
+class HydeUriPathHelperTest extends TestCase
+{
+    public function testHelperReturnsFalseWhenNoSiteUrlIsSet()
+    {
+        \Illuminate\Support\Facades\Config::set('hyde.site_url');
+        $this->assertFalse(Hyde::uriPath());
+    }
+
+    public function testHelperReturnsExpectedStringWhenSiteUrlIsSet()
+    {
+        \Illuminate\Support\Facades\Config::set('hyde.site_url', 'https://example.com');
+        $this->assertEquals('https://example.com/foo/bar.html', Hyde::uriPath('foo/bar.html'));
+    }
+}

--- a/tests/Unit/HydeUriPathHelperTest.php
+++ b/tests/Unit/HydeUriPathHelperTest.php
@@ -6,13 +6,13 @@ use Tests\TestCase;
 
 class HydeUriPathHelperTest extends TestCase
 {
-    public function testHelperReturnsFalseWhenNoSiteUrlIsSet()
+    public function test_helper_returns_false_when_no_site_url_is_set()
     {
         \Illuminate\Support\Facades\Config::set('hyde.site_url');
         $this->assertFalse(Hyde::uriPath());
     }
 
-    public function testHelperReturnsExpectedStringWhenSiteUrlIsSet()
+    public function test_helper_returns_expected_string_when_site_url_is_set()
     {
         \Illuminate\Support\Facades\Config::set('hyde.site_url', 'https://example.com');
         $this->assertEquals('https://example.com/foo/bar.html', Hyde::uriPath('foo/bar.html'));

--- a/tests/Unit/MarkdownConverterTest.php
+++ b/tests/Unit/MarkdownConverterTest.php
@@ -12,7 +12,7 @@ use Tests\TestCase;
  */
 class MarkdownConverterTest extends TestCase
 {
-    public function testParse(): void
+    public function test_parse(): void
     {
         $markdown = '# Hello World!';
 

--- a/tests/Unit/MarkdownPostParserTest.php
+++ b/tests/Unit/MarkdownPostParserTest.php
@@ -19,7 +19,7 @@ class MarkdownPostParserTest extends TestCase
         parent::setUp();
 
         // Create a Markdown file to work with
-        copy(Hyde::path('tests/_stubs/_posts/test-parser-post.md'), $this->getPath());
+        copy(Hyde::path('vendor/hyde/framework/tests/stubs/_posts/test-parser-post.md'), $this->getPath());
     }
 
     /**

--- a/tests/Unit/MarkdownPostParserTest.php
+++ b/tests/Unit/MarkdownPostParserTest.php
@@ -45,7 +45,7 @@ class MarkdownPostParserTest extends TestCase
         return Hyde::path('_posts/test-parser-post.md');
     }
 
-    public function testCanParseMarkdownFile()
+    public function test_can_parse_markdown_file()
     {
         $post = (new MarkdownPostParser('test-parser-post'))->get();
         $this->assertInstanceOf(MarkdownPost::class, $post);
@@ -57,7 +57,7 @@ class MarkdownPostParserTest extends TestCase
         $this->assertTrue(strlen($post->slug) > 8);
     }
 
-    public function testParsedMarkdownPostContainsValidFrontMatter()
+    public function test_parsed_markdown_post_contains_valid_front_matter()
     {
         $post = (new MarkdownPostParser('test-parser-post'))->get();
         $this->assertEquals('My New Post', $post->matter['title']);

--- a/tests/Unit/PublishesDefaultFrontendResourceFilesTest.php
+++ b/tests/Unit/PublishesDefaultFrontendResourceFilesTest.php
@@ -20,7 +20,7 @@ class PublishesDefaultFrontendResourceFilesTest extends TestCase
     }
 
     /** @test */
-    public function testDefaultFilesArePublished()
+    public function test_default_files_are_published()
     {
         $this->assertDirectoryDoesNotExist(Hyde::path('resources/frontend'));
 

--- a/tests/_stubs/_posts/test-parser-post.md
+++ b/tests/_stubs/_posts/test-parser-post.md
@@ -1,9 +1,0 @@
----
-title: My New Post
-category: blog
-author: Mr. Hyde
----
-
-# My New Post
-
-This is a post stub used in the automated tests


### PR DESCRIPTION
This PR is a tie-in to https://github.com/hydephp/framework/pull/72 for Hyde v0.10.x and improves the overall test coverage both by reducing complexity and boilerplate, but also by adding a few new tests for both the new code and existing.