### PR TITLE
Add back _site to Tailwind content array

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -3,6 +3,7 @@ const defaultTheme = require('tailwindcss/defaultTheme');
 module.exports = {
     darkMode: 'class',
     content: [
+		'./_site/**/*.html', // If you have issues with npm run watch getting stuck in a loop, remove this line. See https://github.com/hydephp/hyde/issues/146
         './resources/views/**/*.blade.php',
         './vendor/hyde/framework/resources/views/**/*.blade.php',
     ],

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -3,7 +3,7 @@ const defaultTheme = require('tailwindcss/defaultTheme');
 module.exports = {
     darkMode: 'class',
     content: [
-		'./_site/**/*.html', // If you have issues with npm run watch getting stuck in a loop, remove this line. See https://github.com/hydephp/hyde/issues/146
+        './_site/**/*.html', // If you have issues with npm run watch getting stuck in a loop, remove this line. See https://github.com/hydephp/hyde/issues/146
         './resources/views/**/*.blade.php',
         './vendor/hyde/framework/resources/views/**/*.blade.php',
     ],


### PR DESCRIPTION
Adds back the site glob pattern that can cause an endless loop, but adds a warning. See https://github.com/hydephp/hyde/issues/146