### PR TITLE
Fix #146 by adding _pages to Tailwind content

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -3,7 +3,7 @@ const defaultTheme = require('tailwindcss/defaultTheme');
 module.exports = {
     darkMode: 'class',
     content: [
-        './_site/**/*.html', // If you have issues with npm run watch getting stuck in a loop, remove this line. See https://github.com/hydephp/hyde/issues/146
+        './_pages/*.blade.php',
         './resources/views/**/*.blade.php',
         './vendor/hyde/framework/resources/views/**/*.blade.php',
     ],


### PR DESCRIPTION
The whole issue was caused due to me forgetting to add the _pages directory which now can contain Blade files. The loop should now be fixed since we never touch any site files, nor should we need to. I am still keeping the resources directory as it can contain custom components.