### PR TITLE
Revert "Add job to setup template repositories"

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -10,24 +10,8 @@ on:
     branches: [ "master", "develop" ]
   pull_request:
     branches: [ "master", "develop" ]
-  create:
 
 jobs:
-  setup-template-repository:
-    runs-on: ubuntu-latest
-    name: Setup repository
-    if: github.ref == 'refs/heads/master' && github.event.repository.full_name != 'hydephp/hyde'
-    steps:
-      - uses: actions/checkout@v3
-      - name: Remove workflows from template repository
-        run: rm -rf .github/workflows
-
-      - name: Commit changed files
-        uses: stefanzweifel/git-auto-commit-action@v4
-        with:
-          commit_message: "Setup repository"
-
-
   hyde-tests-master:
     strategy:
       fail-fast: false


### PR DESCRIPTION
This reverts commit fdf44ebfa7933013431dccb507cbc836d940434c and thus partially reverts https://github.com/hydephp/hyde/pull/234 as the complexity caused by permissions is not worth it, and it may violate the principle of least astonishment. The change that skips the jobs remains, so the issue https://github.com/hydephp/hyde/issues/233 remains fixed.