### PR TITLE
Fix bug in .gitattributes causing binary file corruptions

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,4 @@
-* text eol=lf
+* text=auto eol=lf
 
 *.blade.php diff=html
 *.css diff=css


### PR DESCRIPTION
Cherry picks https://github.com/hydephp/develop/pull/1700 for immediate patch release rollout.

> Changing CRLF to LF makes sense for text files, but not images, where doing so can lead to file corruption. This commit tells Git to ignore binary files and only do the substitution in plain text files.
> 
> Fixes hydephp/hyde#239.