### PR TITLE
Add workflow to configure template repository

### DIFF
--- a/.github/workflows/.github/workflows/configure-repository.yml
+++ b/.github/workflows/.github/workflows/configure-repository.yml
@@ -1,0 +1,66 @@
+# When using the Repository Template feature on GitHub, it does not follow the same rules as Composer create-project or ZIP downloads.
+# For this reason, we have this script which will configure the repository the first time it is set up in order to normalize it.
+name: Configure template repository
+
+on:
+  # Run when branch is created (when the repository is generated from the template)
+  create:
+
+# Only keep latest run of this workflow and cancel any previous runs
+concurrency:
+  group: first-time-setup
+  cancel-in-progress: true
+
+permissions: 
+  actions: write
+  checks: write
+  contents: write
+  
+jobs:
+  first-time-setup:
+    runs-on: ubuntu-latest
+
+    # Ensure is is only run once, when the repository is generated
+    if: github.run_number == 1
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Remove workflow files
+        run: rm -rf .github/workflows
+       
+      - name: Remove files in export-ignore
+        run: |
+          # Define the path to the .gitattributes file
+          gitattributes=".gitattributes"
+
+          # Check if the .gitattributes file exists
+          if [ ! -f "$gitattributes" ]; then
+              echo "Error: .gitattributes file not found."
+              exit 1
+          fi
+
+          # Read the .gitattributes file line by line
+          while IFS= read -r line; do
+              # Check if the line contains 'export-ignore'
+              if [[ $line == *"export-ignore"* ]]; then
+                  # Extract the path from the line
+                  path=$(echo "$line" | awk '{print $1}')
+                  # Check if the path exists and delete it
+                  if [ -e "$path" ]; then
+                      echo "Deleting path: $path"
+                      rm -rf "$path"
+                  else
+                      echo "Path does not exist: $path"
+                  fi
+              fi
+          done < "$gitattributes"
+
+      - name: Commit changed files
+        run: |
+          git config --global user.name "GitHub Actions"
+          git config --global user.email "actions@github.com"
+          git add .
+          git commit -m "Configure template repository"
+          git push

--- a/.github/workflows/.github/workflows/configure-repository.yml
+++ b/.github/workflows/.github/workflows/configure-repository.yml
@@ -27,9 +27,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Remove workflow files
-        run: rm -rf .github/workflows
-       
       - name: Remove files in export-ignore
         run: |
           # Define the path to the .gitattributes file

--- a/.github/workflows/.github/workflows/configure-repository.yml
+++ b/.github/workflows/.github/workflows/configure-repository.yml
@@ -29,9 +29,6 @@ jobs:
 
       - name: Remove files in export-ignore
         run: |
-          # Define the path to the .gitattributes file
-          gitattributes=".gitattributes"
-
           # Read the .gitattributes file line by line
           while IFS= read -r line; do
               # Check if the line contains 'export-ignore'
@@ -40,7 +37,7 @@ jobs:
                   path=$(echo "$line" | awk '{print $1}')
                   rm -rf "$path"
               fi
-          done < "$gitattributes"
+          done < ".gitattributes"
 
       - name: Commit changed files
         run: |

--- a/.github/workflows/.github/workflows/configure-repository.yml
+++ b/.github/workflows/.github/workflows/configure-repository.yml
@@ -32,25 +32,13 @@ jobs:
           # Define the path to the .gitattributes file
           gitattributes=".gitattributes"
 
-          # Check if the .gitattributes file exists
-          if [ ! -f "$gitattributes" ]; then
-              echo "Error: .gitattributes file not found."
-              exit 1
-          fi
-
           # Read the .gitattributes file line by line
           while IFS= read -r line; do
               # Check if the line contains 'export-ignore'
               if [[ $line == *"export-ignore"* ]]; then
                   # Extract the path from the line
                   path=$(echo "$line" | awk '{print $1}')
-                  # Check if the path exists and delete it
-                  if [ -e "$path" ]; then
-                      echo "Deleting path: $path"
-                      rm -rf "$path"
-                  else
-                      echo "Path does not exist: $path"
-                  fi
+                  rm -rf "$path"
               fi
           done < "$gitattributes"
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,8 +1,3 @@
-# README: This workflow runs some tests intended to make sure that the package works smoothly.
-#         This file is not included when you install Hyde normally, however it is present
-#         when you create a project by using the GitHub template. Unless you want to
-#         contribute to the project, there's no reason for you to keep this file.
-
 name: Hyde Tests
 
 on:


### PR DESCRIPTION
When using the Repository Template feature on GitHub, it does not follow the same rules as Composer create-project or ZIP downloads.

For this reason, we have this script which will configure the repository the first time it is set up in order to normalize it.

See https://github.com/orgs/community/discussions/22183

Fixes https://github.com/hydephp/hyde/issues/233