### PR TITLE
Fix documentation links not using the v2 version

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ See the documentation and learn more at https://hydephp.com/docs
 
 ## Getting Started - High-level overview
 
-> See [Installation Guide](https://hydephp.com/docs/1.x/installation) and [Getting Started](https://hydephp.com/docs/1.x/getting-started) for the full details.
+> See [Installation Guide](https://hydephp.com/docs/2.x/installation) and [Getting Started](https://hydephp.com/docs/2.x/getting-started) for the full details.
 
 It's a breeze to get started with Hyde. Create a new Hyde project using Composer:
 

--- a/_pages/index.blade.php
+++ b/_pages/index.blade.php
@@ -65,7 +65,7 @@
                             </a>
                         </li>
                         <li>
-                            <a href="https://hydephp.com/docs/1.x/getting-started" class="uppercase font-bold text-sm flex text-center m-2 mx-3">
+                            <a href="https://hydephp.com/docs/2.x/getting-started" class="uppercase font-bold text-sm flex text-center m-2 mx-3">
                                 Getting Started
                             </a>
                         </li>

--- a/config/docs.php
+++ b/config/docs.php
@@ -94,7 +94,7 @@ return [
     | Collaborative Source Editing Location
     |--------------------------------------------------------------------------
     |
-    | @see https://hydephp.com/docs/1.x/documentation-pages#automatic-edit-page-button
+    | @see https://hydephp.com/docs/2.x/documentation-pages#automatic-edit-page-button
     |
     | By adding a base URL here, Hyde will use it to create "edit source" links
     | to your documentation pages. Hyde expects this to be a GitHub path, but
@@ -118,7 +118,7 @@ return [
     |--------------------------------------------------------------------------
     |
     | Hyde comes with an easy to use search feature for documentation pages.
-    | @see https://hydephp.com/docs/1.x/documentation-pages#search-feature
+    | @see https://hydephp.com/docs/2.x/documentation-pages#search-feature
     |
     */
 

--- a/config/hyde.php
+++ b/config/hyde.php
@@ -313,7 +313,7 @@ return [
     | You can disable it completely by changing the setting to `false`.
     |
     | To read about the many configuration options here, visit:
-    | https://hydephp.com/docs/1.x/customization#footer
+    | https://hydephp.com/docs/2.x/customization#footer
     |
     */
 

--- a/config/markdown.php
+++ b/config/markdown.php
@@ -75,7 +75,7 @@ return [
     | arbitrary PHP to run. But if your Markdown is trusted, try it out!
     |
     | To see the syntax and usage, see the documentation:
-    | @see https://hydephp.com/docs/1.x/advanced-markdown#blade-support
+    | @see https://hydephp.com/docs/2.x/advanced-markdown#blade-support
     |
     */
 

--- a/resources/assets/app.css
+++ b/resources/assets/app.css
@@ -8,7 +8,7 @@
 * so you don't need to compile this file unless you're making changes to Tailwind styles.
 *
 * If you want, you can load the compiled file with minified styles for a base install from the CDN.
-* See https://hydephp.com/docs/1.x/managing-assets#loading-from-cdn
+* See https://hydephp.com/docs/2.x/managing-assets#loading-from-cdn
 */
 
 @import 'hydefront/components/torchlight.css' layer(base);

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,6 +1,6 @@
 // Using Vite is optional, as the styles you need to get started are already included.
 // However, if you customize existing or add new Tailwind classes, you can use Vite
-// to compile the assets. See https://hydephp.com/docs/1.x/managing-assets.html.
+// to compile the assets. See https://hydephp.com/docs/2.x/managing-assets.html.
 
 import { defineConfig } from 'vite';
 import tailwindcss from "@tailwindcss/vite";


### PR DESCRIPTION
Merges https://github.com/hydephp/develop/pull/2503 from https://github.com/hydephp/develop/commit/0066846cd7f1a02203566be75d303a087f46c930